### PR TITLE
Fix "Error reading revision BASE of <filename>."

### DIFF
--- a/src/usr/bin/diffuse
+++ b/src/usr/bin/diffuse
@@ -2561,7 +2561,7 @@ class _Svn:
     def getRevision(self, prefs, name, rev):
         vcs_bin = prefs.getString('svn_bin')
         if rev in [ 'BASE', 'COMMITTED', 'PREV' ]:
-            return popenRead(self.root, [ vcs_bin, 'cat', '%s@%s' % (safeRelativePath(self.root, name, prefs, 'svn_cygwin'), rev) ], prefs, 'svn_bash')
+            return popenRead(self.root, [ vcs_bin, 'cat', '%s@%s' % (relpath(self.root, os.path.abspath(name)).replace(os.sep, '/'), rev) ], prefs, 'svn_bash')
         return popenRead(self.root, [ vcs_bin, 'cat', '%s/%s@%s' % (self._getURL(prefs), relpath(self.root, os.path.abspath(name)).replace(os.sep, '/'), rev) ], prefs, 'svn_bash')
 
 def _get_svn_repo(path, prefs):


### PR DESCRIPTION
Environment:
Linux w/ SVN repository.
Reproduction:
Run _diffuse -m_ in repository directory.
Symptom:
Dialog is displayed with 'Error reading revision BASE of <filename>.

This request fixes the issue on linux, I have not tested with cygwin.
I see when printing the old SVN command:
print('%s@%s' % (safeRelativePath(self.root, name, prefs, 'svn_cygwin'), rev))
output is:
b'./<filename>'@BASE

I don't see where the leading b is coming from.