### PR TITLE
Fix error when using '-m' in an SVN repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fixed missing directories when uninstalling
 - fixed bug introduced by r420 with RCS VCS
 - fixed broken drag'n'drop since migration to Python3/GTK3
+- fixed error when using '-m' in an SVN repo
 
 ## [0.4.8] - 2014-07-18
 ### Added

--- a/src/usr/bin/diffuse
+++ b/src/usr/bin/diffuse
@@ -1334,7 +1334,6 @@ def relpath(a, b):
 # by prepending './' to the basename
 def safeRelativePath(abspath1, name, prefs, cygwin_pref):
     s = os.path.join(os.curdir, relpath(abspath1, os.path.abspath(name)))
-    s = codecs.encode(s, sys.getfilesystemencoding())
     if isWindows():
         if prefs.getBool(cygwin_pref):
             s = s.replace('\\', '/')


### PR DESCRIPTION
Alternative to the fix proposed @rkroetch (#51) about a bug he found. I think this fix is a bit better since `safeRelativePath` is used at several places.

I am unsure it won't break something else, but since the main difference between Python 2 and 3 is that UTF-8 is the default text format, I assume `codecs.encode` is not useful any more.