### PR TITLE
Add Flatpak config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,20 @@ Diffuse.  The `XDG_CONFIG_HOME` and `XDG_DATA_DIR` environment variables
 indicate where Diffuse should store persistent settings (eg. the path to a
 writable directory on the pen drive).
 
+## Building and testing the Flatpak package
+
+To install Diffuse locally:
+
+    flatpak-builder builddir-flatpak --user --install com.github.mightycreak.Diffuse.yml
+
+To run Diffuse through Flatpak:
+
+    flatpak run com.github.mightycreak.Diffuse
+
+To uninstall Diffuse:
+
+    flatpak remove com.github.mightycreak.Diffuse
+
 ## Help Documentation
 
 Diffuse's help documentation is written in the DocBook format and can be easily

--- a/com.github.mightycreak.Diffuse.yml
+++ b/com.github.mightycreak.Diffuse.yml
@@ -1,0 +1,19 @@
+app-id: com.github.mightycreak.Diffuse
+runtime: org.gnome.Platform
+runtime-version: '3.36'
+sdk: org.gnome.Sdk
+command: diffuse
+finish-args:
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --filesystem=home
+modules:
+  - name: diffuse
+    buildsystem: meson
+    sources:
+      - type: git
+        url: https://github.com/MightyCreak/diffuse
+        branch: master
+rename-desktop-file: diffuse.desktop
+rename-icon: diffuse


### PR DESCRIPTION
Will eventually fix #65

This is an experiment to deploy Diffuse using Flatpak.

To install Diffuse locally:

    flatpak-builder builddir-flatpak --user --install com.github.mightycreak.Diffuse.yml

To run Diffuse through Flatpak:

    flatpak run com.github.mightycreak.Diffuse

To uninstall Diffuse:

    flatpak remove com.github.mightycreak.Diffuse