### PR TITLE
Fix SyntaxError in utils.py

### DIFF
--- a/src/diffuse/utils.py
+++ b/src/diffuse/utils.py
@@ -182,14 +182,13 @@ def popenRead(dn, cmd, prefs, bash_pref, success_results=None):
         info = None
     if _use_flatpak():
         cmd = ['flatpak-spawn', '--host'] + cmd
-    with (subprocess.Popen(
-        cmd,
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        cwd=dn,
-        startupinfo=info) as proc
-    ):
+    with subprocess.Popen(
+            cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=dn,
+            startupinfo=info) as proc:
         proc.stdin.close()
         proc.stderr.close()
         fd = proc.stdout


### PR DESCRIPTION
Fixes #137

No idea if this reintroduces a lint error that 812ca1779f9537153d57fd89a08c6957361d93ac tried to solve -- we'll see.