### PR TITLE
Fix preferences crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Translation: added French translation
 
 ### Fixed
+- Fixed #156: Preferences cannot be saved in latest release
 - Cleanups: use constructors instead of `new()` whenever possible in GTK
   classes
 

--- a/src/diffuse/preferences.py
+++ b/src/diffuse/preferences.py
@@ -277,7 +277,8 @@ class Preferences:
             for k in self.int_prefs:
                 self.int_prefs[k] = widgets[k].get_value_as_int()
             for k in self.string_prefs:
-                self.string_prefs[k] = utils.null_to_empty(widgets[k].get_text())
+                text = self._getWidgetText(widgets[k])
+                self.string_prefs[k] = utils.null_to_empty(text)
             try:
                 ss = []
                 for k, bool_value in self.bool_prefs.items():
@@ -374,6 +375,20 @@ class Preferences:
                 entry.show()
             table.show()
         return table
+
+    def _getWidgetText(self, widget):
+        text = ""
+        if (
+            isinstance(widget, Gtk.Entry) or
+            isinstance(widget, utils.EncodingMenu) or
+            isinstance(widget, _FileEntry)
+        ):
+            text = widget.get_text()
+        elif isinstance(widget, Gtk.FontButton):
+            text = widget.get_font()
+        else:
+            raise TypeError(f"Don't know how to get text from type: {type(widget)}")
+        return text
 
     # get/set methods to manipulate the preference values
     def getBool(self, name: str) -> bool:


### PR DESCRIPTION
`get_text` was not defined on all the widgets

* Use `get_text` when available in widget
* Use `get_font` when widget is a `Gtk.FontButton`
* Raise TypeError exception otherwise

Fixes #156 