### PR TITLE
Refer to pip3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Translation: updated Swedish translation (thanks to @eson57)
 
+- Documentation: prefer `pip3` over `pip` to ensure it works everywhere (thanks to @krlmlr)
+ 
 ## 0.7.7 - 2022-10-23
 
 ### Changed

--- a/docs/developers/developers-setup.md
+++ b/docs/developers/developers-setup.md
@@ -53,13 +53,13 @@ _Note: Tested on macOS 12.5 (Monterey)_
 To install the requirements just to execute the binary, run:
 
 ```sh
-pip install -r requirements.txt
+pip3 install -r requirements.txt
 ```
 
 For developer tools, run this one instead (it includes requirements.txt):
 
 ```sh
-pip install -r requirements.dev.txt
+pip3 install -r requirements.dev.txt
 ```
 
 ## Setup


### PR DESCRIPTION
from developer instructions.

- Safer
- Plain `pip` might be unavailable.