### PR TITLE
Don't need root on macOS

### DIFF
--- a/docs/developers/developers-setup.md
+++ b/docs/developers/developers-setup.md
@@ -37,7 +37,7 @@ _Note: Tested on Fedora 36_
 </details>
 
 <details>
-    <summary>Mac OS</summary>
+    <summary>macOS</summary>
 
 On Mac, all dependencies can be installed using [Homebrew](https://docs.brew.sh/):
 
@@ -108,7 +108,7 @@ meson test
 
 #### Install on system and run
 
-To install Diffuse on your system (e.g. `/usr/local/`):
+To install Diffuse on your system (e.g. `/usr/local`):
 
 ```sh
 meson install # requires admin privileges
@@ -148,11 +148,11 @@ sudo ninja uninstall -C build
 sudo rm -v /usr/local/share/locale/*/LC_MESSAGES/diffuse.mo
 ```
 
-### Setup on macOS using Meson
+### Setup on macOS
 
 #### Build and test
 
-Diffuse is using Meson as its build system.
+Diffuse is using Meson as its build system, this is the only supported system on macOS.
 
 To build and test Diffuse:
 
@@ -165,10 +165,12 @@ meson test
 
 #### Install on system and run
 
-To install Diffuse on your system (e.g., `/Applications` and `/opt/homebrew` or `/usr/local/`):
+To install Diffuse on your system (e.g., `/Applications` and `/opt/homebrew` or `/usr/local`):
 
 ```sh
-meson install # might require admin privileges
+# requires the user to have admin privileges, or sudo
+meson install
+# sudo meson install
 ```
 
 To run Diffuse:

--- a/docs/developers/developers-setup.md
+++ b/docs/developers/developers-setup.md
@@ -148,7 +148,7 @@ sudo ninja uninstall -C build
 sudo rm -v /usr/local/share/locale/*/LC_MESSAGES/diffuse.mo
 ```
 
-### Setup on Mac OS
+### Setup on macOS using Meson
 
 #### Build and test
 
@@ -165,7 +165,7 @@ meson test
 
 #### Install on system and run
 
-To install Diffuse on your system (e.g. `/usr/local/`):
+To install Diffuse on your system (e.g., `/Applications` and `/opt/homebrew` or `/usr/local/`):
 
 ```sh
 meson install # might require admin privileges
@@ -177,8 +177,7 @@ To run Diffuse:
 diffuse
 ```
 
-_Note: The `diffuse` command can be used to launch Diffuse as a native Mac app_
-_that is installed into `/Applications/Diffuse.app`._
+_Note: The `diffuse` command can be used to launch Diffuse as a native Mac app that is installed into `/Applications/Diffuse.app`. To pass command-line arguments, run `diffuse_impl`. _
 
 ### Setup on Windows (deprecated)
 

--- a/docs/developers/developers-setup.md
+++ b/docs/developers/developers-setup.md
@@ -179,7 +179,7 @@ To run Diffuse:
 diffuse
 ```
 
-_Note: The `diffuse` command can be used to launch Diffuse as a native Mac app that is installed into `/Applications/Diffuse.app`. To pass command-line arguments, run `diffuse_impl`. _
+_Note: The `diffuse` command can be used to launch Diffuse as a native Mac app that is installed into `/Applications/Diffuse.app`._
 
 ### Setup on Windows (deprecated)
 

--- a/docs/developers/developers-setup.md
+++ b/docs/developers/developers-setup.md
@@ -168,7 +168,7 @@ meson test
 To install Diffuse on your system (e.g. `/usr/local/`):
 
 ```sh
-meson install # requires admin privileges
+meson install # might require admin privileges
 ```
 
 To run Diffuse:

--- a/docs/developers/developers-setup.md
+++ b/docs/developers/developers-setup.md
@@ -111,7 +111,7 @@ meson test
 To install Diffuse on your system (e.g. `/usr/local/`):
 
 ```sh
-meson install # requires admin privileges
+meson install  # requires admin privileges
 ```
 
 To run Diffuse:

--- a/docs/developers/developers-setup.md
+++ b/docs/developers/developers-setup.md
@@ -108,7 +108,7 @@ meson test
 
 #### Install on system and run
 
-To install Diffuse on your system (e.g. `/usr/local`):
+To install Diffuse on your system (e.g. `/usr/local/`):
 
 ```sh
 meson install # requires admin privileges
@@ -152,7 +152,8 @@ sudo rm -v /usr/local/share/locale/*/LC_MESSAGES/diffuse.mo
 
 #### Build and test
 
-Diffuse is using Meson as its build system, this is the only supported system on macOS.
+Diffuse is using Meson as its build system, this is the only supported system
+on macOS.
 
 To build and test Diffuse:
 
@@ -165,12 +166,11 @@ meson test
 
 #### Install on system and run
 
-To install Diffuse on your system (e.g., `/Applications` and `/opt/homebrew` or `/usr/local`):
+To install Diffuse on your system (e.g. `/Applications/` and `/opt/homebrew/`
+or `/usr/local/`):
 
 ```sh
-# requires the user to have admin privileges, or sudo
-meson install
-# sudo meson install
+meson install  # requires admin privileges
 ```
 
 To run Diffuse:
@@ -179,7 +179,8 @@ To run Diffuse:
 diffuse
 ```
 
-_Note: The `diffuse` command can be used to launch Diffuse as a native Mac app that is installed into `/Applications/Diffuse.app`._
+_Note: The `diffuse` command can be used to launch Diffuse as a native Mac app_
+_that is installed into `/Applications/Diffuse.app`._
 
 ### Setup on Windows (deprecated)
 


### PR DESCRIPTION
At least not on my machine.

Includes a change to make the `build/` directory very explicit.