### PR TITLE
Prompt once to reload if more than one file modified externally (bis)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Language: initial support for Rust language (thanks to @alopatindev)
+- Language: initial support for Rust language (@alopatindev)
 
 ### Changed
 
-- Translation: updated Swedish translation (thanks to @eson57)
+- Translation: updated Swedish translation (@eson57)
+- Dialog: prompt only once if several files needs to be reloaded (@yuriiz)
+
+### Fixed
+
+- fix: "Go to line..." dialog didn't show up (@MightyCreak)
+- Tech debt: use `transient_for` instead of the deprecated `parent` when creating
+  a `Gtk.Widget` (@MightyCreak)
 
 ## 0.7.7 - 2022-10-23
 
 ### Changed
 
-- Translation: updated Spanish translation (thanks to @oscfdezdz)
+- Translation: updated Spanish translation (@oscfdezdz)
 - Translation: updated POT file
 - Translation: fixed issue with commented string that still needs translation
 
@@ -27,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Port to Mac OS (thanks to @hugoholgersson)
+- Port to Mac OS (@hugoholgersson)
 
 ### Changed
 

--- a/data/io.github.mightycreak.Diffuse.appdata.xml.in
+++ b/data/io.github.mightycreak.Diffuse.appdata.xml.in
@@ -48,7 +48,7 @@
         </p>
         <p>Added:</p>
         <ul>
-          <li>Port to Mac OS (thanks to @hugoholgersson)</li>
+          <li>Port to Mac OS (@hugoholgersson)</li>
         </ul>
         <p>Changed:</p>
         <ul>

--- a/src/diffuse/utils.py
+++ b/src/diffuse/utils.py
@@ -169,7 +169,7 @@ def popenRead(
         cmd: List[str],
         prefs: Preferences,
         bash_pref: str,
-        success_results: List[int] = None) -> bytes:
+        success_results: Optional[List[int]] = None) -> bytes:
     if success_results is None:
         success_results = [0]
 
@@ -239,7 +239,7 @@ def popenReadLines(
         cmd: List[str],
         prefs: Preferences,
         bash_pref: str,
-        success_results: List[int] = None) -> List[str]:
+        success_results: Optional[List[int]] = None) -> List[str]:
     return _strip_eols(splitlines(popenRead(
         cwd, cmd, prefs, bash_pref, success_results).decode('utf-8', errors='ignore')))
 

--- a/src/diffuse/utils.py
+++ b/src/diffuse/utils.py
@@ -38,18 +38,18 @@ from gi.repository import Gtk  # type: ignore # noqa: E402
 
 # convenience class for displaying a message dialogue
 class MessageDialog(Gtk.MessageDialog):
-    def __init__(self, parent: Gtk.Widget, message_type: Gtk.MessageType, s: str) -> None:
+    def __init__(self, parent: Gtk.Widget, message_type: Gtk.MessageType, text: str) -> None:
         if message_type == Gtk.MessageType.ERROR:
             buttons = Gtk.ButtonsType.OK
         else:
             buttons = Gtk.ButtonsType.OK_CANCEL
         Gtk.MessageDialog.__init__(
             self,
-            parent=parent,
+            transient_for=parent,
             destroy_with_parent=True,
             message_type=message_type,
             buttons=buttons,
-            text=s)
+            text=text)
         self.set_title(constants.APP_NAME)
 
 
@@ -57,15 +57,15 @@ class MessageDialog(Gtk.MessageDialog):
 class EncodingMenu(Gtk.Box):
     def __init__(self, prefs: Preferences, autodetect: bool = False) -> None:
         Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL)
-        self.combobox = combobox = Gtk.ComboBoxText()
+        self.combobox = Gtk.ComboBoxText()
         self.encodings = prefs.getEncodings()[:]
         for e in self.encodings:
-            combobox.append_text(e)
+            self.combobox.append_text(e)
         if autodetect:
+            self.combobox.prepend_text(_('Auto Detect'))
             self.encodings.insert(0, None)
-            combobox.prepend_text(_('Auto Detect'))
-        self.pack_start(combobox, False, False, 0)
-        combobox.show()
+        self.pack_start(self.combobox, False, False, 0)
+        self.combobox.show()
 
     def set_text(self, encoding: Optional[str]) -> None:
         encoding = norm_encoding(encoding)


### PR DESCRIPTION
This PR is based on #93, but I couldn't push on top of it so I had to create a new PR.

In this PR:
* Create only one dialog even if multiple files has been changed on disk
* fix: the calls to `NumericDialog` weren't working
* use `transient_for` instead of `parent` when creating new `Gtk.Dialog`
* Changelog: I removed the "thanks to" (just kept the mentions to the users), because it felt weird to put "thanks to myself" :sweat_smile: 

Fixes #16 