### PR TITLE
fix: reference the images from the repo directly

### DIFF
--- a/data/io.github.mightycreak.Diffuse.appdata.xml.in
+++ b/data/io.github.mightycreak.Diffuse.appdata.xml.in
@@ -23,11 +23,11 @@
 
   <screenshots>
     <screenshot type="default">
-      <image type="source">https://mightycreak.github.io/diffuse/docs/images/screenshot_v0.7.7_main_window.png</image>
+      <image type="source">https://github.com/MightyCreak/diffuse/raw/master/docs/images/screenshot_v0.7.7_main_window.png</image>
       <caption>Main window</caption>
     </screenshot>
     <screenshot>
-      <image type="source">https://mightycreak.github.io/diffuse/docs/images/screenshot_v0.7.7_about_window.png</image>
+      <image type="source">https://github.com/MightyCreak/diffuse/raw/master/docs/images/screenshot_v0.7.7_about_window.png</image>
       <caption>About window</caption>
     </screenshot>
   </screenshots>


### PR DESCRIPTION
There is a recursive dependency between the repo and the `appstream-util` tool.

This doesn't fix it entirely, but at least we don't need to reprocess the CI twice because the GitHub Pages action isn't finished yet and the images aren't published to the website.