### PR TITLE
fix: quick fix for the GTK accelerators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `logError` logs on stderr (@MightyCreak)
 - Change Git default branch from `master` to `main` (@MightyCreak)
 
+### Fixed
+
+- Shortcuts were not working since the move to Gtk.Application
+  (issue [#188](https://github.com/MightyCreak/diffuse/issues/188)) (@MightyCreak)
+
 ## 0.8.0 - 2023-04-03
 
 ### Added

--- a/src/diffuse/window.py
+++ b/src/diffuse/window.py
@@ -973,20 +973,20 @@ class DiffuseWindow(Gtk.ApplicationWindow):
                 else:
                     if cb_data is not None:
                         cb_data = GLib.Variant.new_string(cb_data)
-                    accel = accel.replace('_', '-')
+                    gtk_compliant_accel = accel.replace('_', '-')
                     if cb is not None:
-                        action = Gio.SimpleAction.new(accel, cb_data and cb_data.get_type())
+                        cb_data_type = cb_data and cb_data.get_type()
+                        action = Gio.SimpleAction.new(gtk_compliant_accel, cb_data_type)
                         action.connect('activate', cb)
                         self.add_action(action)
                     item = Gio.MenuItem.new(label)
-                    item.set_action_and_target_value('win.' + accel, cb_data)
+                    item.set_action_and_target_value('win.' + gtk_compliant_accel, cb_data)
                     key_binding = theResources.getKeyBindings('menu', accel)
                     if len(key_binding) > 0:
-                        key, modifier = key_binding[0]
-                        self.get_application().set_accels_for_action(
-                            Gio.Action.print_detailed_name('win.' + accel, cb_data),
-                            [Gtk.accelerator_name(key, modifier)],
-                        )
+                        action_name = 'win.' + gtk_compliant_accel
+                        detailed_action_name = Gio.Action.print_detailed_name(action_name, cb_data)
+                        accels = [Gtk.accelerator_name(*key_binding[0])]
+                        self.get_application().set_accels_for_action(detailed_action_name, accels)
                     section_menu.append_item(item)
             menu.append_section(None, section_menu)
         return menu


### PR DESCRIPTION
Fixes #188 

It was related to the GTK action names. Only the action names defined in the `menu` bindings are used with `Gio.Action.print_detailed_name` which doesn't tolerate `_` in the action name. This is a quick fix (of a quick fix :sweat_smile: ) and this time it properly formats the action name as GTK would expect it.