### PR TITLE
Proper fix for accelerators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add link to the Matrix room in the README (@MightyCreak)
 
+### Changed
+
+- Replace `_` by `-` in the action names to be compatible with GTK action names (@MightyCreak)
+
 ## 0.8.1 - 2023-04-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Some signals weren't properly renamed from the previous GTK3 migration (@MightyCreak)
+- The syntax menu wasn't working anymore (@MightyCreak)
 
 ## 0.8.1 - 2023-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replace `_` by `-` in the action names to be compatible with GTK action names (@MightyCreak)
 
+### Fixed
+
+- Some signals weren't properly renamed from the previous GTK3 migration (@MightyCreak)
+
 ## 0.8.1 - 2023-04-07
 
 ### Changed

--- a/data/usr/share/gnome/help/diffuse/C/diffuse.xml
+++ b/data/usr/share/gnome/help/diffuse/C/diffuse.xml
@@ -644,7 +644,7 @@
 
         <variablelist>
           <varlistentry>
-            <term><userinput>open_file</userinput></term>
+            <term><userinput>open-file</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>File</guimenu><guimenuitem>Open File...</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Ctrl+o</literal></para>
@@ -652,7 +652,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>open_file_in_new_tab</userinput></term>
+            <term><userinput>open-file-in-new-tab</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>File</guimenu><guimenuitem>Open File In New Tab...</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Ctrl+t</literal></para>
@@ -660,7 +660,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>open_modified_files</userinput></term>
+            <term><userinput>open-modified-files</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>File</guimenu><guimenuitem>Open Modified Files...</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Shift+Ctrl+O</literal></para>
@@ -668,7 +668,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>open_commit</userinput></term>
+            <term><userinput>open-commit</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>File</guimenu><guimenuitem>Open Commit...</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Shift+Ctrl+T</literal></para>
@@ -676,7 +676,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>reload_file</userinput></term>
+            <term><userinput>reload-file</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>File</guimenu><guimenuitem>Reload File</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Shift+Ctrl+R</literal></para>
@@ -684,7 +684,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>save_file</userinput></term>
+            <term><userinput>save-file</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>File</guimenu><guimenuitem>Save File</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Ctrl+s</literal></para>
@@ -692,7 +692,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>save_file_as</userinput></term>
+            <term><userinput>save-file-as</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>File</guimenu><guimenuitem>Save File As...</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Shift+Ctrl+A</literal></para>
@@ -700,7 +700,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>save_all</userinput></term>
+            <term><userinput>save-all</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>File</guimenu><guimenuitem>Save All</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Shift+Ctrl+S</literal></para>
@@ -708,7 +708,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>new_2_way_file_merge</userinput></term>
+            <term><userinput>new-2-way-file-merge</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>File</guimenu><guimenuitem>New 2-Way File Merge</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Ctrl+2</literal></para>
@@ -716,7 +716,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>new_3_way_file_merge</userinput></term>
+            <term><userinput>new-3-way-file-merge</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>File</guimenu><guimenuitem>New 3-Way File Merge</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Ctrl+3</literal></para>
@@ -724,7 +724,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>new_n_way_file_merge</userinput></term>
+            <term><userinput>new-n-way-file-merge</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>File</guimenu><guimenuitem>New N-Way File Merge</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Ctrl+4</literal></para>
@@ -732,7 +732,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>close_tab</userinput></term>
+            <term><userinput>close-tab</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>File</guimenu><guimenuitem>Close Tab</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Ctrl+w</literal></para>
@@ -740,7 +740,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>undo_close_tab</userinput></term>
+            <term><userinput>undo-close-tab</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>File</guimenu><guimenuitem>Undo Close Tab</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Shift+Ctrl+w</literal></para>
@@ -796,7 +796,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>select_all</userinput></term>
+            <term><userinput>select-all</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Edit</guimenu><guimenuitem>Select All</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Ctrl+a</literal></para>
@@ -804,7 +804,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>clear_edits</userinput></term>
+            <term><userinput>clear-edits</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Edit</guimenu><guimenuitem>Clear Edits</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Ctrl+r</literal></para>
@@ -812,7 +812,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>dismiss_all_edits</userinput></term>
+            <term><userinput>dismiss-all-edits</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Edit</guimenu><guimenuitem>Dismiss All Edits</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Ctrl+d</literal></para>
@@ -828,7 +828,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>find_next</userinput></term>
+            <term><userinput>find-next</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Edit</guimenu><guimenuitem>Find Next</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Ctrl+g</literal></para>
@@ -836,7 +836,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>find_previous</userinput></term>
+            <term><userinput>find-previous</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Edit</guimenu><guimenuitem>Find Previous</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Shift+Ctrl+G</literal></para>
@@ -844,7 +844,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>go_to_line</userinput></term>
+            <term><userinput>go-to-line</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Edit</guimenu><guimenuitem>Go To Line...</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Shift+Ctrl+L</literal></para>
@@ -860,7 +860,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>no_syntax_highlighting</userinput></term>
+            <term><userinput>no-syntax-highlighting</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>View</guimenu><guisubmenu>Syntax Highlighting</guisubmenu><guimenuitem>None</guimenuitem></menuchoice> menu item</para>
               <para>Default: None</para>
@@ -868,7 +868,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>syntax_highlighting_<replaceable>syntax</replaceable></userinput></term>
+            <term><userinput>syntax-highlighting-<replaceable>syntax</replaceable></userinput></term>
             <listitem>
               <para><menuchoice><guimenu>View</guimenu><guisubmenu>Syntax Highlighting</guisubmenu><guimenuitem><replaceable>syntax</replaceable></guimenuitem></menuchoice> menu item</para>
               <para>Default: None</para>
@@ -876,7 +876,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>realign_all</userinput></term>
+            <term><userinput>realign-all</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>View</guimenu><guimenuitem>Realign All</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Ctrl+l</literal></para>
@@ -892,7 +892,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>first_difference</userinput></term>
+            <term><userinput>first-difference</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>View</guimenu><guimenuitem>First Difference</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Shift+Ctrl+Up</literal></para>
@@ -900,7 +900,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>previous_difference</userinput></term>
+            <term><userinput>previous-difference</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>View</guimenu><guimenuitem>Previous Difference</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Ctrl+Up</literal></para>
@@ -908,7 +908,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>next_difference</userinput></term>
+            <term><userinput>next-difference</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>View</guimenu><guimenuitem>Next Difference</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Ctrl+Down</literal></para>
@@ -916,7 +916,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>last_difference</userinput></term>
+            <term><userinput>last-difference</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>View</guimenu><guimenuitem>Last Difference</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Shift+Ctrl+Down</literal></para>
@@ -924,7 +924,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>first_tab</userinput></term>
+            <term><userinput>first-tab</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>View</guimenu><guimenuitem>First Tab</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Shift+Ctrl+Page_Up</literal></para>
@@ -932,7 +932,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>previous_tab</userinput></term>
+            <term><userinput>previous-tab</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>View</guimenu><guimenuitem>Previous Tab</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Ctrl+Page_Up</literal></para>
@@ -940,7 +940,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>next_tab</userinput></term>
+            <term><userinput>next-tab</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>View</guimenu><guimenuitem>Next Tab</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Ctrl+Page_Down</literal></para>
@@ -948,7 +948,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>last_tab</userinput></term>
+            <term><userinput>last-tab</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>View</guimenu><guimenuitem>Last Tab</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Shift+Ctrl+Page_Down</literal></para>
@@ -956,7 +956,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>shift_pane_right</userinput></term>
+            <term><userinput>shift-pane-right</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>View</guimenu><guimenuitem>Shift Pane Right</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Shift+Ctrl+parenleft</literal></para>
@@ -964,7 +964,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>shift_pane_left</userinput></term>
+            <term><userinput>shift-pane-left</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>View</guimenu><guimenuitem>Shift Pane Left</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Shift+Ctrl+parenright</literal></para>
@@ -972,7 +972,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>convert_to_upper_case</userinput></term>
+            <term><userinput>convert-to-upper-case</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Format</guimenu><guimenuitem>Convert To Upper Case</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Ctrl+u</literal></para>
@@ -980,7 +980,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>convert_to_lower_case</userinput></term>
+            <term><userinput>convert-to-lower-case</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Format</guimenu><guimenuitem>Convert To Lower Case</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Shift+Ctrl+U</literal></para>
@@ -988,7 +988,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>sort_lines_in_ascending_order</userinput></term>
+            <term><userinput>sort-lines-in-ascending-order</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Format</guimenu><guimenuitem>Sort Lines In Ascending Order</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Ctrl+y</literal></para>
@@ -996,7 +996,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>sort_lines_in_descending_order</userinput></term>
+            <term><userinput>sort-lines-in-descending-order</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Format</guimenu><guimenuitem>Sort Lines In Descending Order</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Shift+Ctrl+Y</literal></para>
@@ -1004,7 +1004,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>remove_trailing_white_space</userinput></term>
+            <term><userinput>remove-trailing-white-space</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Format</guimenu><guimenuitem>Remove Trailing White Space</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Ctrl+k</literal></para>
@@ -1012,7 +1012,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>convert_tabs_to_spaces</userinput></term>
+            <term><userinput>convert-tabs-to-spaces</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Format</guimenu><guimenuitem>Convert Tabs To Spaces</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Ctrl+b</literal></para>
@@ -1020,7 +1020,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>convert_leading_spaces_to_tabs</userinput></term>
+            <term><userinput>convert-leading-spaces-to-tabs</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Format</guimenu><guimenuitem>Convert Leading Spaces To Tabs</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Shift+Ctrl+B</literal></para>
@@ -1028,7 +1028,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>increase_indenting</userinput></term>
+            <term><userinput>increase-indenting</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Format</guimenu><guimenuitem>Increase Indenting</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Shift+Ctrl+greater</literal></para>
@@ -1036,7 +1036,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>decrease_indenting</userinput></term>
+            <term><userinput>decrease-indenting</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Format</guimenu><guimenuitem>Decrease Indenting</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Shift+Ctrl+less</literal></para>
@@ -1044,7 +1044,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>convert_to_dos</userinput></term>
+            <term><userinput>convert-to-dos</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Format</guimenu><guimenuitem>Convert To DOS Format</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Shift+Ctrl+E</literal></para>
@@ -1052,7 +1052,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>convert_to_mac</userinput></term>
+            <term><userinput>convert-to-mac</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Format</guimenu><guimenuitem>Convert To Mac Format</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Shift+Ctrl+C</literal></para>
@@ -1060,7 +1060,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>convert_to_unix</userinput></term>
+            <term><userinput>convert-to-unix</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Format</guimenu><guimenuitem>Convert To Unix Format</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Ctrl+e</literal></para>
@@ -1068,7 +1068,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_selection_right</userinput></term>
+            <term><userinput>copy-selection-right</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Merge</guimenu><guimenuitem>Copy Selection Right</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Shift+Ctrl+Right</literal></para>
@@ -1076,7 +1076,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_selection_left</userinput></term>
+            <term><userinput>copy-selection-left</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Merge</guimenu><guimenuitem>Copy Selection Left</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Shift+Ctrl+Left</literal></para>
@@ -1084,7 +1084,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_left_into_selection</userinput></term>
+            <term><userinput>copy-left-into-selection</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Merge</guimenu><guimenuitem>Copy Left Into Selection</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Ctrl+Right</literal></para>
@@ -1092,7 +1092,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_right_into_selection</userinput></term>
+            <term><userinput>copy-right-into-selection</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Merge</guimenu><guimenuitem>Copy Right Into Selection</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Ctrl+Left</literal></para>
@@ -1100,7 +1100,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>merge_from_left_then_right</userinput></term>
+            <term><userinput>merge-from-left-then-right</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Merge</guimenu><guimenuitem>Merge From Left Then Right</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Ctrl+m</literal></para>
@@ -1108,7 +1108,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>merge_from_right_then_left</userinput></term>
+            <term><userinput>merge-from-right-then-left</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Merge</guimenu><guimenuitem>Merge From Right Then Left</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>Shift+Ctrl+M</literal></para>
@@ -1116,7 +1116,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>help_contents</userinput></term>
+            <term><userinput>help-contents</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Help</guimenu><guimenuitem>Help Contents</guimenuitem></menuchoice> menu item</para>
               <para>Default: <literal>F1</literal></para>
@@ -1137,7 +1137,7 @@
         <title>Line Editing Mode Key Bindings</title>
 
         <para>
-          Use <userinput>line_mode</userinput> for the
+          Use <userinput>line-mode</userinput> for the
           <replaceable>context</replaceable> to define key bindings for line
           editing mode.  The following values are valid for
           <replaceable>action</replaceable>:
@@ -1145,7 +1145,7 @@
 
         <variablelist>
           <varlistentry>
-            <term><userinput>enter_align_mode</userinput></term>
+            <term><userinput>enter-align-mode</userinput></term>
             <listitem>
               <para>enter alignment editing mode</para>
               <para>Default: <literal>space</literal></para>
@@ -1153,7 +1153,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>enter_character_mode</userinput></term>
+            <term><userinput>enter-character-mode</userinput></term>
             <listitem>
               <para>enter character editing mode</para>
               <para>Defaults: <literal>Return</literal>, <literal>KP_Enter</literal></para>
@@ -1161,7 +1161,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>first_line</userinput></term>
+            <term><userinput>first-line</userinput></term>
             <listitem>
               <para>move cursor to the first line</para>
               <para>Defaults: <literal>Home</literal>, <literal>g</literal></para>
@@ -1169,7 +1169,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_first_line</userinput></term>
+            <term><userinput>extend-first-line</userinput></term>
             <listitem>
               <para>move cursor to the first line, extending the selection</para>
               <para>Default: <literal>Shift+Home</literal></para>
@@ -1177,7 +1177,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>last_line</userinput></term>
+            <term><userinput>last-line</userinput></term>
             <listitem>
               <para>move cursor to the last line</para>
               <para>Defaults: <literal>End</literal>, <literal>Shift+G</literal></para>
@@ -1185,7 +1185,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_last_line</userinput></term>
+            <term><userinput>extend-last-line</userinput></term>
             <listitem>
               <para>move cursor to the last line, extending the selection</para>
               <para>Default: <literal>Shift+End</literal></para>
@@ -1201,7 +1201,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_up</userinput></term>
+            <term><userinput>extend-up</userinput></term>
             <listitem>
               <para>move cursor up one line, extending the selection</para>
               <para>Defaults: <literal>Shift+Up</literal>, <literal>Shift+K</literal></para>
@@ -1217,7 +1217,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_down</userinput></term>
+            <term><userinput>extend-down</userinput></term>
             <listitem>
               <para>move cursor down one line, extending the selection</para>
               <para>Defaults: <literal>Shift+Down</literal>, <literal>Shift+J</literal></para>
@@ -1233,7 +1233,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_left</userinput></term>
+            <term><userinput>extend-left</userinput></term>
             <listitem>
               <para>move cursor left one file, extending the selection</para>
               <para>Default: <literal>Shift+Left</literal></para>
@@ -1249,7 +1249,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_right</userinput></term>
+            <term><userinput>extend-right</userinput></term>
             <listitem>
               <para>move cursor right one file, extending the selection</para>
               <para>Default: <literal>Shift+Right</literal></para>
@@ -1257,7 +1257,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>page_up</userinput></term>
+            <term><userinput>page-up</userinput></term>
             <listitem>
               <para>move cursor up one page</para>
               <para>Defaults: <literal>Page_Up</literal>, <literal>Ctrl+u</literal></para>
@@ -1265,7 +1265,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_page_up</userinput></term>
+            <term><userinput>extend-page-up</userinput></term>
             <listitem>
               <para>move cursor up one page, extending the selection</para>
               <para>Defaults: <literal>Shift+Page_Up</literal>, <literal>Shift+Ctrl+u</literal></para>
@@ -1273,7 +1273,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>page_down</userinput></term>
+            <term><userinput>page-down</userinput></term>
             <listitem>
               <para>move cursor down one page</para>
               <para>Defaults: <literal>Page_Down</literal>, <literal>Ctrl+d</literal></para>
@@ -1281,7 +1281,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_page_down</userinput></term>
+            <term><userinput>extend-page-down</userinput></term>
             <listitem>
               <para>move cursor down one page, extending the selection</para>
               <para>Defaults: <literal>Shift+Page_Down</literal>, <literal>Shift+Ctrl+d</literal></para>
@@ -1289,7 +1289,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>delete_text</userinput></term>
+            <term><userinput>delete-text</userinput></term>
             <listitem>
               <para>delete the selected text</para>
               <para>Defaults: <literal>BackSpace</literal>, <literal>Delete</literal>, <literal>x</literal></para>
@@ -1297,7 +1297,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>first_difference</userinput></term>
+            <term><userinput>first-difference</userinput></term>
             <listitem>
               <para>select the first difference</para>
               <para>Defaults: <literal>Ctrl+Home</literal>, <literal>Shift+P</literal></para>
@@ -1305,7 +1305,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>previous_difference</userinput></term>
+            <term><userinput>previous-difference</userinput></term>
             <listitem>
               <para>select the previous difference</para>
               <para>Default: <literal>p</literal></para>
@@ -1313,7 +1313,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>next_difference</userinput></term>
+            <term><userinput>next-difference</userinput></term>
             <listitem>
               <para>select the next difference</para>
               <para>Default: <literal>n</literal></para>
@@ -1321,7 +1321,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>last_difference</userinput></term>
+            <term><userinput>last-difference</userinput></term>
             <listitem>
               <para>select the last difference</para>
               <para>Defaults: <literal>Ctrl+End</literal>, <literal>Shift+N</literal></para>
@@ -1329,7 +1329,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>clear_edits</userinput></term>
+            <term><userinput>clear-edits</userinput></term>
             <listitem>
               <para>clear all edits from the selected lines</para>
               <para>Default: <literal>r</literal></para>
@@ -1337,7 +1337,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_selection_left</userinput></term>
+            <term><userinput>copy-selection-left</userinput></term>
             <listitem>
               <para>copy lines from the selection into the file on the left</para>
               <para>Default: None</para>
@@ -1345,7 +1345,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_selection_right</userinput></term>
+            <term><userinput>copy-selection-right</userinput></term>
             <listitem>
               <para>copy lines from the selection into the file on the right</para>
               <para>Default: None</para>
@@ -1353,7 +1353,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_left_into_selection</userinput></term>
+            <term><userinput>copy-left-into-selection</userinput></term>
             <listitem>
               <para>copy lines from the file on the left into the selection</para>
               <para>Default: <literal>Shift+L</literal></para>
@@ -1361,7 +1361,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_right_into_selection</userinput></term>
+            <term><userinput>copy-right-into-selection</userinput></term>
             <listitem>
               <para>copy lines from the file on the right into the selection</para>
               <para>Default: <literal>Shift+H</literal></para>
@@ -1369,7 +1369,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>merge_from_left_then_right</userinput></term>
+            <term><userinput>merge-from-left-then-right</userinput></term>
             <listitem>
               <para>merge lines from file on the left then file on the right</para>
               <para>Default: <literal>m</literal></para>
@@ -1377,7 +1377,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>merge_from_right_then_left</userinput></term>
+            <term><userinput>merge-from-right-then-left</userinput></term>
             <listitem>
               <para>merge lines from file on the right then file on the left</para>
               <para>Default: <literal>Shift+M</literal></para>
@@ -1398,7 +1398,7 @@
         <title>Alignment Editing Mode Key Bindings</title>
 
         <para>
-          Use <userinput>align_mode</userinput> for the
+          Use <userinput>align-mode</userinput> for the
           <replaceable>context</replaceable> to define key bindings for
           alignment editing mode.  The following values are valid for
           <replaceable>action</replaceable>:
@@ -1406,7 +1406,7 @@
 
         <variablelist>
           <varlistentry>
-            <term><userinput>enter_line_mode</userinput></term>
+            <term><userinput>enter-line-mode</userinput></term>
             <listitem>
               <para>enter line editing mode</para>
               <para>Default: <literal>Escape</literal></para>
@@ -1414,7 +1414,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>enter_character_mode</userinput></term>
+            <term><userinput>enter-character-mode</userinput></term>
             <listitem>
               <para>enter character editing mode</para>
               <para>Defaults: <literal>Return</literal>, <literal>KP_Enter</literal></para>
@@ -1422,7 +1422,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>first_line</userinput></term>
+            <term><userinput>first-line</userinput></term>
             <listitem>
               <para>move cursor to the first line</para>
               <para>Default: <literal>g</literal></para>
@@ -1430,7 +1430,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>last_line</userinput></term>
+            <term><userinput>last-line</userinput></term>
             <listitem>
               <para>move cursor to the last line</para>
               <para>Default: <literal>Shift+G</literal></para>
@@ -1470,7 +1470,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>page_up</userinput></term>
+            <term><userinput>page-up</userinput></term>
             <listitem>
               <para>move cursor up one page</para>
               <para>Defaults: <literal>Page_Up</literal>, <literal>Ctrl+u</literal></para>
@@ -1478,7 +1478,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>page_down</userinput></term>
+            <term><userinput>page-down</userinput></term>
             <listitem>
               <para>move cursor down one page</para>
               <para>Defaults: <literal>Page_Down</literal>, <literal>Ctrl+d</literal></para>
@@ -1499,7 +1499,7 @@
         <title>Character Editing Mode Key Bindings</title>
 
         <para>
-          Use <userinput>character_mode</userinput> for the
+          Use <userinput>character-mode</userinput> for the
           <replaceable>context</replaceable> to define key bindings for
           character editing mode.  The following values are valid for
           <replaceable>action</replaceable>:
@@ -1507,7 +1507,7 @@
 
         <variablelist>
           <varlistentry>
-            <term><userinput>enter_line_mode</userinput></term>
+            <term><userinput>enter-line-mode</userinput></term>
             <listitem>
               <para>enter line editing mode</para>
               <para>Default: <literal>Escape</literal></para>

--- a/data/usr/share/gnome/help/diffuse/cs/diffuse.xml
+++ b/data/usr/share/gnome/help/diffuse/cs/diffuse.xml
@@ -394,7 +394,7 @@
 
         <variablelist>
           <varlistentry>
-            <term><userinput>open_file</userinput></term>
+            <term><userinput>open-file</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Soubor</guimenu><guimenuitem>Otevřít soubor...</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Ctrl+o</literal></para>
@@ -402,7 +402,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>open_file_in_new_tab</userinput></term>
+            <term><userinput>open-file-in-new-tab</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Soubor</guimenu><guimenuitem>Otevřít v novém panelu...</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Ctrl+t</literal></para>
@@ -410,7 +410,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>open_modified_files</userinput></term>
+            <term><userinput>open-modified-files</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Soubor</guimenu><guimenuitem>Otevřít změněné soubory...</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Shift+Ctrl+O</literal></para>
@@ -418,7 +418,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>open_commit</userinput></term>
+            <term><userinput>open-commit</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Soubor</guimenu><guimenuitem>Otevřít revizi...</guimenuitem></menuchoice> menu item</para>
               <para>Výchozí: <literal>Shift+Ctrl+T</literal></para>
@@ -426,7 +426,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>reload_file</userinput></term>
+            <term><userinput>reload-file</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Soubor</guimenu><guimenuitem>Znovu načíst soubor</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Shift+Ctrl+R</literal></para>
@@ -434,7 +434,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>save_file</userinput></term>
+            <term><userinput>save-file</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Soubor</guimenu><guimenuitem>Uložit soubor</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Ctrl+s</literal></para>
@@ -442,7 +442,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>save_file_as</userinput></term>
+            <term><userinput>save-file-as</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Soubor</guimenu><guimenuitem>Uložit soubor jako...</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Shift+Ctrl+A</literal></para>
@@ -450,7 +450,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>save_all</userinput></term>
+            <term><userinput>save-all</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Soubor</guimenu><guimenuitem>Uložit vše</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Shift+Ctrl+S</literal></para>
@@ -458,7 +458,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>new_2_way_file_merge</userinput></term>
+            <term><userinput>new-2-way-file-merge</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Soubor</guimenu><guimenuitem>Nové 2směrné slučování</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Ctrl+2</literal></para>
@@ -466,7 +466,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>new_3_way_file_merge</userinput></term>
+            <term><userinput>new-3-way-file-merge</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Soubor</guimenu><guimenuitem>Nové 3směrné slučování</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Ctrl+3</literal></para>
@@ -474,7 +474,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>new_n_way_file_merge</userinput></term>
+            <term><userinput>new-n-way-file-merge</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Soubor</guimenu><guimenuitem>Nové Nsměrné slučování</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Ctrl+4</literal></para>
@@ -482,7 +482,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>close_tab</userinput></term>
+            <term><userinput>close-tab</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Soubor</guimenu><guimenuitem>Zavřít panel</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Ctrl+w</literal></para>
@@ -490,7 +490,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>undo_close_tab</userinput></term>
+            <term><userinput>undo-close-tab</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Soubor</guimenu><guimenuitem>Obnovit zavřený panel</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Shift+Ctrl+w</literal></para>
@@ -546,7 +546,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>select_all</userinput></term>
+            <term><userinput>select-all</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Úpravy</guimenu><guimenuitem>Označit vše</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Ctrl+a</literal></para>
@@ -554,7 +554,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>clear_edits</userinput></term>
+            <term><userinput>clear-edits</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Úpravy</guimenu><guimenuitem>Smazat úpravy</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Ctrl+r</literal></para>
@@ -562,7 +562,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>dismiss_all_edits</userinput></term>
+            <term><userinput>dismiss-all-edits</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Úpravy</guimenu><guimenuitem>Zrušit všechny úpravy</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Ctrl+d</literal></para>
@@ -578,7 +578,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>find_next</userinput></term>
+            <term><userinput>find-next</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Úpravy</guimenu><guimenuitem>Najít další</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Ctrl+g</literal></para>
@@ -586,7 +586,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>find_previous</userinput></term>
+            <term><userinput>find-previous</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Úpravy</guimenu><guimenuitem>Najít předchozí</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Shift+Ctrl+G</literal></para>
@@ -594,7 +594,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>go_to_line</userinput></term>
+            <term><userinput>go-to-line</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Úpravy</guimenu><guimenuitem>Přejít na řádek...</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Shift+Ctrl+L</literal></para>
@@ -610,7 +610,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>no_syntax_highlighting</userinput></term>
+            <term><userinput>no-syntax-highlighting</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Zobrazit</guimenu><guisubmenu>Zvýraznění syntaxe</guisubmenu><guimenuitem>Nic</guimenuitem></menuchoice></para>
               <para>Výchozí: None</para>
@@ -618,7 +618,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>syntax_highlighting_<replaceable>syntaxe</replaceable></userinput></term>
+            <term><userinput>syntax-highlighting-<replaceable>syntaxe</replaceable></userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Zobrazit</guimenu><guisubmenu>Zvýraznění syntaxe</guisubmenu><guimenuitem><replaceable>syntaxe</replaceable></guimenuitem></menuchoice></para>
               <para>Výchozí: None</para>
@@ -626,7 +626,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>realign_all</userinput></term>
+            <term><userinput>realign-all</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Zobrazit</guimenu><guimenuitem>Znovu zarovnat</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Ctrl+l</literal></para>
@@ -642,7 +642,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>first_difference</userinput></term>
+            <term><userinput>first-difference</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Zobrazit</guimenu><guimenuitem>První rozdíl</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Shift+Ctrl+Up</literal></para>
@@ -650,7 +650,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>previous_difference</userinput></term>
+            <term><userinput>previous-difference</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Zobrazit</guimenu><guimenuitem>Předchozí rozdíl</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Ctrl+Up</literal></para>
@@ -658,7 +658,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>next_difference</userinput></term>
+            <term><userinput>next-difference</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Zobrazit</guimenu><guimenuitem>Další rozdíl</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Ctrl+Down</literal></para>
@@ -666,7 +666,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>last_difference</userinput></term>
+            <term><userinput>last-difference</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Zobrazit</guimenu><guimenuitem>Poslední rozdíl</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Shift+Ctrl+Down</literal></para>
@@ -674,7 +674,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>first_tab</userinput></term>
+            <term><userinput>first-tab</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Zobrazit</guimenu><guimenuitem>První panel</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Shift+Ctrl+Page_Up</literal></para>
@@ -682,7 +682,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>previous_tab</userinput></term>
+            <term><userinput>previous-tab</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Zobrazit</guimenu><guimenuitem>Předchozí panel</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Ctrl+Page_Up</literal></para>
@@ -690,7 +690,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>next_tab</userinput></term>
+            <term><userinput>next-tab</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Zobrazit</guimenu><guimenuitem>Další panel</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Ctrl+Page_Down</literal></para>
@@ -698,7 +698,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>last_tab</userinput></term>
+            <term><userinput>last-tab</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Zobrazit</guimenu><guimenuitem>Poslední panel</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Shift+Ctrl+Page_Down</literal></para>
@@ -706,7 +706,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>shift_pane_right</userinput></term>
+            <term><userinput>shift-pane-right</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Zobrazit</guimenu><guimenuitem>Přesunout podokno doprava</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Shift+Ctrl+parenleft</literal></para>
@@ -714,7 +714,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>shift_pane_left</userinput></term>
+            <term><userinput>shift-pane-left</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Zobrazit</guimenu><guimenuitem>Přesunout podokno doleva</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Shift+Ctrl+parenright</literal></para>
@@ -722,7 +722,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>convert_to_upper_case</userinput></term>
+            <term><userinput>convert-to-upper-case</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Formát</guimenu><guimenuitem>Převést na velká písmena</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Ctrl+u</literal></para>
@@ -730,7 +730,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>convert_to_lower_case</userinput></term>
+            <term><userinput>convert-to-lower-case</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Formát</guimenu><guimenuitem>Převést na malá písmena</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Shift+Ctrl+U</literal></para>
@@ -738,7 +738,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>sort_lines_in_ascending_order</userinput></term>
+            <term><userinput>sort-lines-in-ascending-order</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Formát</guimenu><guimenuitem>Seřadit řádky vzestupně</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Ctrl+y</literal></para>
@@ -746,7 +746,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>sort_lines_in_descending_order</userinput></term>
+            <term><userinput>sort-lines-in-descending-order</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Formát</guimenu><guimenuitem>Seřadit řádky sestupně</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Shift+Ctrl+Y</literal></para>
@@ -754,7 +754,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>remove_trailing_white_space</userinput></term>
+            <term><userinput>remove-trailing-white-space</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Formát</guimenu><guimenuitem>Odstranit mezery na koncích řádků</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Ctrl+k</literal></para>
@@ -762,7 +762,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>convert_tabs_to_spaces</userinput></term>
+            <term><userinput>convert-tabs-to-spaces</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Formát</guimenu><guimenuitem>Nahradit tabulátory mezerami</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Ctrl+b</literal></para>
@@ -770,7 +770,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>convert_leading_spaces_to_tabs</userinput></term>
+            <term><userinput>convert-leading-spaces-to-tabs</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Formát</guimenu><guimenuitem>Nahradit úvodní mezery tabulátory</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Shift+Ctrl+B</literal></para>
@@ -778,7 +778,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>increase_indenting</userinput></term>
+            <term><userinput>increase-indenting</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Formát</guimenu><guimenuitem>Zvětšit odsazení</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Shift+Ctrl+&gt;</literal></para>
@@ -786,7 +786,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>decrease_indenting</userinput></term>
+            <term><userinput>decrease-indenting</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Formát</guimenu><guimenuitem>Zmenšit odsazení</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Shift+Ctrl+&lt;</literal></para>
@@ -794,7 +794,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>convert_to_dos</userinput></term>
+            <term><userinput>convert-to-dos</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Formát</guimenu><guimenuitem>Převést na DOS formát</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Shift+Ctrl+E</literal></para>
@@ -802,7 +802,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>convert_to_mac</userinput></term>
+            <term><userinput>convert-to-mac</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Formát</guimenu><guimenuitem>Převést na Mac formát</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Shift+Ctrl+C</literal></para>
@@ -810,7 +810,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>convert_to_unix</userinput></term>
+            <term><userinput>convert-to-unix</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Formát</guimenu><guimenuitem>Převést na Unix formát</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Ctrl+e</literal></para>
@@ -818,7 +818,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_selection_right</userinput></term>
+            <term><userinput>copy-selection-right</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Sloučit</guimenu><guimenuitem>Kopírovat výběr doprava</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Shift+Ctrl+Right</literal></para>
@@ -826,7 +826,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_selection_left</userinput></term>
+            <term><userinput>copy-selection-left</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Sloučit</guimenu><guimenuitem>Kopírovat výběr doleva</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Shift+Ctrl+Left</literal></para>
@@ -834,7 +834,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_left_into_selection</userinput></term>
+            <term><userinput>copy-left-into-selection</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Sloučit</guimenu><guimenuitem>Kopírovat zleva do výběru</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Ctrl+Right</literal></para>
@@ -842,7 +842,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_right_into_selection</userinput></term>
+            <term><userinput>copy-right-into-selection</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Sloučit</guimenu><guimenuitem>Kopírovat zprava do výběru</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Ctrl+Left</literal></para>
@@ -850,7 +850,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>merge_from_left_then_right</userinput></term>
+            <term><userinput>merge-from-left-then-right</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Sloučit</guimenu><guimenuitem>Sloučit zleva a poté zprava</guimenuitem></menuchoice> menu item</para>
               <para>Výchozí: <literal>Ctrl+m</literal></para>
@@ -858,7 +858,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>merge_from_right_then_left</userinput></term>
+            <term><userinput>merge-from-right-then-left</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Sloučit</guimenu><guimenuitem>Sloučit zprava a poté zleva</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>Shift+Ctrl+M</literal></para>
@@ -866,7 +866,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>help_contents</userinput></term>
+            <term><userinput>help-contents</userinput></term>
             <listitem>
               <para>Položka nabídky <menuchoice><guimenu>Nápověda</guimenu><guimenuitem>Zobrazit nápovědu</guimenuitem></menuchoice></para>
               <para>Výchozí: <literal>F1</literal></para>
@@ -886,11 +886,11 @@
       <sect2 id="resources-keybindings-line_mode">
         <title>Přiřazení klávesových zkratek pro řádkový režim úprav</title>
 
-        <para>Pro přiřazení klávesových zkratek pro řádkový režim úprav použijte pro parametr <replaceable>kontext</replaceable> hodnotu <userinput>line_mode</userinput>. Platné hodnoty parametru <replaceable>akce</replaceable> jsou:</para>
+        <para>Pro přiřazení klávesových zkratek pro řádkový režim úprav použijte pro parametr <replaceable>kontext</replaceable> hodnotu <userinput>line-mode</userinput>. Platné hodnoty parametru <replaceable>akce</replaceable> jsou:</para>
 
         <variablelist>
           <varlistentry>
-            <term><userinput>enter_align_mode</userinput></term>
+            <term><userinput>enter-align-mode</userinput></term>
             <listitem>
               <para>aktivovat režim úprav zarovnání</para>
               <para>Výchozí: <literal>space</literal></para>
@@ -898,7 +898,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>enter_character_mode</userinput></term>
+            <term><userinput>enter-character-mode</userinput></term>
             <listitem>
               <para>aktivovat znakový režim úprav</para>
               <para>Výchozí: <literal>Return</literal>, <literal>KP_Enter</literal></para>
@@ -906,7 +906,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>first_line</userinput></term>
+            <term><userinput>first-line</userinput></term>
             <listitem>
               <para>přesunout kurzor na první řádek</para>
               <para>Výchozí: <literal>Home</literal>, <literal>g</literal></para>
@@ -914,7 +914,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_first_line</userinput></term>
+            <term><userinput>extend-first-line</userinput></term>
             <listitem>
               <para>přesunout kurzor na první řádek a rozšířit výběr</para>
               <para>Výchozí: <literal>Shift+Home</literal></para>
@@ -922,7 +922,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>last_line</userinput></term>
+            <term><userinput>last-line</userinput></term>
             <listitem>
               <para>přesunout kurzor na poslední řádek</para>
               <para>Výchozí: <literal>End</literal>, <literal>Shift+G</literal></para>
@@ -930,7 +930,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_last_line</userinput></term>
+            <term><userinput>extend-last-line</userinput></term>
             <listitem>
               <para>přesunout kurzor na poslední řádek a rozšířit výběr</para>
               <para>Výchozí: <literal>Shift+End</literal></para>
@@ -946,7 +946,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_up</userinput></term>
+            <term><userinput>extend-up</userinput></term>
             <listitem>
               <para>posunout kurzor o jeden řádek nahoru a rozšířit výběr</para>
               <para>Výchozí: <literal>Shift+Up</literal>, <literal>Shift+K</literal></para>
@@ -962,7 +962,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_down</userinput></term>
+            <term><userinput>extend-down</userinput></term>
             <listitem>
               <para>posunout kurzor o jeden řádek dolů a rozšířit výběr</para>
               <para>Výchozí: <literal>Shift+Down</literal>, <literal>Shift+J</literal></para>
@@ -978,7 +978,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_left</userinput></term>
+            <term><userinput>extend-left</userinput></term>
             <listitem>
               <para>přesunout kurzor o soubor doleva a rozšířit výběr</para>
               <para>Výchozí: <literal>Shift+Left</literal></para>
@@ -994,7 +994,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_right</userinput></term>
+            <term><userinput>extend-right</userinput></term>
             <listitem>
               <para>přesunout kurzor o soubor doprava a rozšířit výběr</para>
               <para>Výchozí: <literal>Shift+Right</literal></para>
@@ -1002,7 +1002,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>page_up</userinput></term>
+            <term><userinput>page-up</userinput></term>
             <listitem>
               <para>přesunout kurzor o stránku nahoru</para>
               <para>Výchozí: <literal>Page_Up</literal>, <literal>Ctrl+u</literal></para>
@@ -1010,7 +1010,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_page_up</userinput></term>
+            <term><userinput>extend-page-up</userinput></term>
             <listitem>
               <para>přesunout kurzor o stránku nahoru a rozšířit výběr</para>
               <para>Výchozí: <literal>Shift+Page_Up</literal>, <literal>Shift+Ctrl+u</literal></para>
@@ -1018,7 +1018,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>page_down</userinput></term>
+            <term><userinput>page-down</userinput></term>
             <listitem>
               <para>přesunout kurzor o stránku dolů</para>
               <para>Výchozí: <literal>Page_Down</literal>, <literal>Ctrl+d</literal></para>
@@ -1026,7 +1026,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_page_down</userinput></term>
+            <term><userinput>extend-page-down</userinput></term>
             <listitem>
               <para>přesunout kurzor o stránku dolů a rozšířit výběr</para>
               <para>Výchozí: <literal>Shift+Page_Down</literal>, <literal>Shift+Ctrl+d</literal></para>
@@ -1034,7 +1034,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>delete_text</userinput></term>
+            <term><userinput>delete-text</userinput></term>
             <listitem>
               <para>smazat vybraný text</para>
               <para>Výchozí: <literal>BackSpace</literal>, <literal>Delete</literal>, <literal>x</literal></para>
@@ -1042,7 +1042,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>first_difference</userinput></term>
+            <term><userinput>first-difference</userinput></term>
             <listitem>
               <para>vybrat první rozdíl</para>
               <para>Výchozí: <literal>Ctrl+Home</literal>, <literal>Shift+P</literal></para>
@@ -1050,7 +1050,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>previous_difference</userinput></term>
+            <term><userinput>previous-difference</userinput></term>
             <listitem>
               <para>vybrat předchozí rozdíl</para>
               <para>Výchozí: <literal>p</literal></para>
@@ -1058,7 +1058,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>next_difference</userinput></term>
+            <term><userinput>next-difference</userinput></term>
             <listitem>
               <para>vybrat další rozdíl</para>
               <para>Výchozí: <literal>n</literal></para>
@@ -1066,7 +1066,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>last_difference</userinput></term>
+            <term><userinput>last-difference</userinput></term>
             <listitem>
               <para>vybrat poslední rozdíl</para>
               <para>Výchozí: <literal>Ctrl+End</literal>, <literal>Shift+N</literal></para>
@@ -1074,7 +1074,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>clear_edits</userinput></term>
+            <term><userinput>clear-edits</userinput></term>
             <listitem>
               <para>smazat všechny úpravy ve vybraných řádcích</para>
               <para>Výchozí: <literal>r</literal></para>
@@ -1082,7 +1082,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_selection_left</userinput></term>
+            <term><userinput>copy-selection-left</userinput></term>
             <listitem>
               <para>zkopírovat vybrané řádky do souboru nalevo</para>
               <para>Výchozí: None</para>
@@ -1090,7 +1090,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_selection_right</userinput></term>
+            <term><userinput>copy-selection-right</userinput></term>
             <listitem>
               <para>zkopírovat vybrané řádky do souboru napravo</para>
               <para>Výchozí: None</para>
@@ -1098,7 +1098,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_left_into_selection</userinput></term>
+            <term><userinput>copy-left-into-selection</userinput></term>
             <listitem>
               <para>zkopírovat do výběru řádky ze souboru nalevo</para>
               <para>Výchozí: <literal>Shift+L</literal></para>
@@ -1106,7 +1106,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_right_into_selection</userinput></term>
+            <term><userinput>copy-right-into-selection</userinput></term>
             <listitem>
               <para>zkopírovat do výběru řádky ze souboru napravo</para>
               <para>Výchozí: <literal>Shift+H</literal></para>
@@ -1114,7 +1114,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>merge_from_left_then_right</userinput></term>
+            <term><userinput>merge-from-left-then-right</userinput></term>
             <listitem>
               <para>sloučit řádky ze souboru nalevo a poté ze souboru napravo</para>
               <para>Výchozí: <literal>m</literal></para>
@@ -1122,7 +1122,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>merge_from_right_then_left</userinput></term>
+            <term><userinput>merge-from-right-then-left</userinput></term>
             <listitem>
               <para>sloučit řádky ze souboru napravo a poté ze souboru nalevo</para>
               <para>Výchozí: <literal>Shift+M</literal></para>
@@ -1142,11 +1142,11 @@
       <sect2 id="resources-keybindings-align_mode">
         <title>Přiřazení klávesových zkratek pro režim úprav zarovnání</title>
 
-        <para>Pro přiřazení klávesových zkratek pro režim úprav zarovnání použijte pro parametr <replaceable>kontext</replaceable> hodnotu <userinput>align_mode</userinput>. Platné hodnoty parametru <replaceable>akce</replaceable> jsou:</para>
+        <para>Pro přiřazení klávesových zkratek pro režim úprav zarovnání použijte pro parametr <replaceable>kontext</replaceable> hodnotu <userinput>align-mode</userinput>. Platné hodnoty parametru <replaceable>akce</replaceable> jsou:</para>
 
         <variablelist>
           <varlistentry>
-            <term><userinput>enter_line_mode</userinput></term>
+            <term><userinput>enter-line-mode</userinput></term>
             <listitem>
               <para>aktivovat řádkový režim úprav</para>
               <para>Výchozí: <literal>Escape</literal></para>
@@ -1154,7 +1154,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>enter_character_mode</userinput></term>
+            <term><userinput>enter-character-mode</userinput></term>
             <listitem>
               <para>aktivovat znakový režim úprav</para>
               <para>Výchozí: <literal>Return</literal>, <literal>KP_Enter</literal></para>
@@ -1162,7 +1162,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>first_line</userinput></term>
+            <term><userinput>first-line</userinput></term>
             <listitem>
               <para>přesunout kurzor na první řádek</para>
               <para>Výchozí: <literal>g</literal></para>
@@ -1170,7 +1170,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>last_line</userinput></term>
+            <term><userinput>last-line</userinput></term>
             <listitem>
               <para>přesunout kurzor na poslední řádek</para>
               <para>Výchozí: <literal>Shift+G</literal></para>
@@ -1210,7 +1210,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>page_up</userinput></term>
+            <term><userinput>page-up</userinput></term>
             <listitem>
               <para>přesunout kurzor o stránku nahoru</para>
               <para>Výchozí: <literal>Page_Up</literal>, <literal>Ctrl+u</literal></para>
@@ -1218,7 +1218,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>page_down</userinput></term>
+            <term><userinput>page-down</userinput></term>
             <listitem>
               <para>přesunout kurzor o stránku dolů</para>
               <para>Výchozí: <literal>Page_Down</literal>, <literal>Ctrl+d</literal></para>
@@ -1238,11 +1238,11 @@
       <sect2 id="resources-keybindings-character_mode">
         <title>Přiřazení klávesových zkratek pro znakový režim úprav</title>
 
-        <para>Pro přiřazení klávesových zkratek pro znakový režim úprav použijte pro parametr <replaceable>kontext</replaceable> hodnotu <userinput>character_mode</userinput>. Platné hodnoty parametru <replaceable>akce</replaceable> jsou:</para>
+        <para>Pro přiřazení klávesových zkratek pro znakový režim úprav použijte pro parametr <replaceable>kontext</replaceable> hodnotu <userinput>character-mode</userinput>. Platné hodnoty parametru <replaceable>akce</replaceable> jsou:</para>
 
         <variablelist>
           <varlistentry>
-            <term><userinput>enter_line_mode</userinput></term>
+            <term><userinput>enter-line-mode</userinput></term>
             <listitem>
               <para>aktivovat řádkový režim úprav</para>
               <para>Výchozí: <literal>Escape</literal></para>

--- a/data/usr/share/gnome/help/diffuse/it/diffuse.xml
+++ b/data/usr/share/gnome/help/diffuse/it/diffuse.xml
@@ -379,7 +379,7 @@
 
         <variablelist>
           <varlistentry>
-            <term><userinput>open_file</userinput></term>
+            <term><userinput>open-file</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>File</guimenu><guimenuitem>Apri file</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Ctrl+o</literal></para>
@@ -387,7 +387,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>open_file_in_new_tab</userinput></term>
+            <term><userinput>open-file-in-new-tab</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>File</guimenu><guimenuitem>Apri file in una nuova scheda...</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Ctrl+t</literal></para>
@@ -395,7 +395,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>open_modified_files</userinput></term>
+            <term><userinput>open-modified-files</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>File</guimenu><guimenuitem>Apri file modificati...</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Shift+Ctrl+O</literal></para>
@@ -403,7 +403,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>open_commit</userinput></term>
+            <term><userinput>open-commit</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>File</guimenu><guimenuitem>Apri commit...</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Shift+Ctrl+T</literal></para>
@@ -411,7 +411,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>reload_file</userinput></term>
+            <term><userinput>reload-file</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>File</guimenu><guimenuitem>Ricarica file</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Shift+Ctrl+R</literal></para>
@@ -419,7 +419,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>save_file</userinput></term>
+            <term><userinput>save-file</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>File</guimenu><guimenuitem>Salva file</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Ctrl+s</literal></para>
@@ -427,7 +427,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>save_file_as</userinput></term>
+            <term><userinput>save-file-as</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>File</guimenu><guimenuitem>Salva con nome...</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Shift+Ctrl+A</literal></para>
@@ -435,7 +435,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>save_all</userinput></term>
+            <term><userinput>save-all</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>File</guimenu><guimenuitem>Salva tutti</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Shift+Ctrl+S</literal></para>
@@ -443,7 +443,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>new_2_way_file_merge</userinput></term>
+            <term><userinput>new-2-way-file-merge</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>File</guimenu><guimenuitem>Nuova unione a 2 file</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Ctrl+2</literal></para>
@@ -451,7 +451,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>new_3_way_file_merge</userinput></term>
+            <term><userinput>new-3-way-file-merge</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>File</guimenu><guimenuitem>Nuova unione a 3 file</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Ctrl+3</literal></para>
@@ -459,7 +459,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>new_n_way_file_merge</userinput></term>
+            <term><userinput>new-n-way-file-merge</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>File</guimenu><guimenuitem>Nuova unione a N file</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Ctrl+4</literal></para>
@@ -467,7 +467,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>close_tab</userinput></term>
+            <term><userinput>close-tab</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>File</guimenu><guimenuitem>Chiudi scheda</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Ctrl+w</literal></para>
@@ -475,7 +475,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>undo_close_tab</userinput></term>
+            <term><userinput>undo-close-tab</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>File</guimenu><guimenuitem>Annulla chiusura scheda</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Shift+Ctrl+w</literal></para>
@@ -531,7 +531,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>select_all</userinput></term>
+            <term><userinput>select-all</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Modifica</guimenu><guimenuitem>Seleziona tutto</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Ctrl+a</literal></para>
@@ -539,7 +539,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>clear_edits</userinput></term>
+            <term><userinput>clear-edits</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Modifica</guimenu><guimenuitem>Annulla modifiche</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Ctrl+r</literal></para>
@@ -547,7 +547,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>dismiss_all_edits</userinput></term>
+            <term><userinput>dismiss-all-edits</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Modifica</guimenu><guimenuitem>Scarta tutte le modifiche</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Ctrl+d</literal></para>
@@ -563,7 +563,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>find_next</userinput></term>
+            <term><userinput>find-next</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Modifica</guimenu><guimenuitem>Trova successivo</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Ctrl+g</literal></para>
@@ -571,7 +571,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>find_previous</userinput></term>
+            <term><userinput>find-previous</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Modifica</guimenu><guimenuitem>Trova precedente</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Shift+Ctrl+G</literal></para>
@@ -579,7 +579,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>go_to_line</userinput></term>
+            <term><userinput>go-to-line</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Modifica</guimenu><guimenuitem>Vai alla riga...</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Shift+Ctrl+L</literal></para>
@@ -595,7 +595,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>no_syntax_highlighting</userinput></term>
+            <term><userinput>no-syntax-highlighting</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Visualizza</guimenu><guisubmenu>Sintassi</guisubmenu><guimenuitem>Nessuna</guimenuitem></menuchoice></para>
               <para>Predefinito: Nessuno</para>
@@ -603,7 +603,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>syntax_highlighting_<replaceable>sintassi</replaceable></userinput></term>
+            <term><userinput>syntax-highlighting-<replaceable>sintassi</replaceable></userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Visualizza</guimenu><guisubmenu>Sintassi</guisubmenu><guimenuitem><replaceable>syntax</replaceable></guimenuitem></menuchoice></para>
               <para>Predefinito: Nessuno</para>
@@ -611,7 +611,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>realign_all</userinput></term>
+            <term><userinput>realign-all</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Visualizza</guimenu><guimenuitem>Riallinea tutto</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Ctrl+l</literal></para>
@@ -627,7 +627,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>first_difference</userinput></term>
+            <term><userinput>first-difference</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Visualizza</guimenu><guimenuitem>Prima differenza</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Shift+Ctrl+Up</literal></para>
@@ -635,7 +635,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>previous_difference</userinput></term>
+            <term><userinput>previous-difference</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Visualizza</guimenu><guimenuitem>Differenza precedente</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Ctrl+Up</literal></para>
@@ -643,7 +643,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>next_difference</userinput></term>
+            <term><userinput>next-difference</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Visualizza</guimenu><guimenuitem>Differenza successiva</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Ctrl+Down</literal></para>
@@ -651,7 +651,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>last_difference</userinput></term>
+            <term><userinput>last-difference</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Visualizza</guimenu><guimenuitem>Ultima differenza</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Shift+Ctrl+Down</literal></para>
@@ -659,7 +659,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>first_tab</userinput></term>
+            <term><userinput>first-tab</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Visualizza</guimenu><guimenuitem>Prima scheda</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Shift+Ctrl+Page_Up</literal></para>
@@ -667,7 +667,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>previous_tab</userinput></term>
+            <term><userinput>previous-tab</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Visualizza</guimenu><guimenuitem>Scheda precedente</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Ctrl+Page_Up</literal></para>
@@ -675,7 +675,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>next_tab</userinput></term>
+            <term><userinput>next-tab</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Visualizza</guimenu><guimenuitem>Scheda successiva</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Ctrl+Page_Down</literal></para>
@@ -683,7 +683,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>last_tab</userinput></term>
+            <term><userinput>last-tab</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Visualizza</guimenu><guimenuitem>Ultima scheda</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Shift+Ctrl+Page_Down</literal></para>
@@ -691,7 +691,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>shift_pane_right</userinput></term>
+            <term><userinput>shift-pane-right</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Visualizza</guimenu><guimenuitem>Sposta riquadro a destra</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Shift+Ctrl+parenleft</literal></para>
@@ -699,7 +699,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>shift_pane_left</userinput></term>
+            <term><userinput>shift-pane-left</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Visualizza</guimenu><guimenuitem>Sposta riquadro a sinistra</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Shift+Ctrl+parenright</literal></para>
@@ -707,7 +707,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>convert_to_upper_case</userinput></term>
+            <term><userinput>convert-to-upper-case</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Formato</guimenu><guimenuitem>Converti in MAIUSCOLO</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Ctrl+u</literal></para>
@@ -715,7 +715,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>convert_to_lower_case</userinput></term>
+            <term><userinput>convert-to-lower-case</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Formato</guimenu><guimenuitem>Converti in minuscolo</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Shift+Ctrl+U</literal></para>
@@ -723,7 +723,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>sort_lines_in_ascending_order</userinput></term>
+            <term><userinput>sort-lines-in-ascending-order</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Formato</guimenu><guimenuitem>Disponi le righe in ordine ascendente</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Ctrl+y</literal></para>
@@ -731,7 +731,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>sort_lines_in_descending_order</userinput></term>
+            <term><userinput>sort-lines-in-descending-order</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Formato</guimenu><guimenuitem>Disponi le righe in ordine discendente</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Shift+Ctrl+Y</literal></para>
@@ -739,7 +739,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>remove_trailing_white_space</userinput></term>
+            <term><userinput>remove-trailing-white-space</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Formato</guimenu><guimenuitem>Rimuovi gli spazi vuoti alla fine della riga</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Ctrl+k</literal></para>
@@ -747,7 +747,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>convert_tabs_to_spaces</userinput></term>
+            <term><userinput>convert-tabs-to-spaces</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Formato</guimenu><guimenuitem>Converti le tabulazioni in spazi</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Ctrl+b</literal></para>
@@ -755,7 +755,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>convert_leading_spaces_to_tabs</userinput></term>
+            <term><userinput>convert-leading-spaces-to-tabs</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Formato</guimenu><guimenuitem>Converti gli spazi iniziali in tabulazioni</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Shift+Ctrl+B</literal></para>
@@ -763,7 +763,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>increase_indenting</userinput></term>
+            <term><userinput>increase-indenting</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Formato</guimenu><guimenuitem>Aumenta indentazione</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Shift+Ctrl+greater</literal></para>
@@ -771,7 +771,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>decrease_indenting</userinput></term>
+            <term><userinput>decrease-indenting</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Formato</guimenu><guimenuitem>Diminuisci indentazione</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Shift+Ctrl+less</literal></para>
@@ -779,7 +779,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>convert_to_dos</userinput></term>
+            <term><userinput>convert-to-dos</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Formato</guimenu><guimenuitem>Converti nel formato DOS</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Shift+Ctrl+E</literal></para>
@@ -787,7 +787,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>convert_to_mac</userinput></term>
+            <term><userinput>convert-to-mac</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Formato</guimenu><guimenuitem>Converti nel formato MAC</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Shift+Ctrl+C</literal></para>
@@ -795,7 +795,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>convert_to_unix</userinput></term>
+            <term><userinput>convert-to-unix</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Formato</guimenu><guimenuitem>Converti nel formato Unix</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Ctrl+e</literal></para>
@@ -803,7 +803,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_selection_right</userinput></term>
+            <term><userinput>copy-selection-right</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Unione</guimenu><guimenuitem>Copia selezione a destra</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Shift+Ctrl+Right</literal></para>
@@ -811,7 +811,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_selection_left</userinput></term>
+            <term><userinput>copy-selection-left</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Unione</guimenu><guimenuitem>Copia selezione a sinistra</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Shift+Ctrl+Left</literal></para>
@@ -819,7 +819,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_left_into_selection</userinput></term>
+            <term><userinput>copy-left-into-selection</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Unione</guimenu><guimenuitem>Copia sinistra nella selezione</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Ctrl+Destra</literal></para>
@@ -827,7 +827,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_right_into_selection</userinput></term>
+            <term><userinput>copy-right-into-selection</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Unione</guimenu><guimenuitem>Copia destra nella selezione</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Ctrl+Sinistra</literal></para>
@@ -835,7 +835,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>merge_from_left_then_right</userinput></term>
+            <term><userinput>merge-from-left-then-right</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Unione</guimenu><guimenuitem>Unisci sinistra poi destra</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Ctrl+m</literal></para>
@@ -843,7 +843,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>merge_from_right_then_left</userinput></term>
+            <term><userinput>merge-from-right-then-left</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Unione</guimenu><guimenuitem>Unisci destra poi sinistra</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>Shift+Ctrl+M</literal></para>
@@ -851,7 +851,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>help_contents</userinput></term>
+            <term><userinput>help-contents</userinput></term>
             <listitem>
               <para>Voce di menu <menuchoice><guimenu>Aiuto</guimenu><guimenuitem>Sommario</guimenuitem></menuchoice></para>
               <para>Predefinito: <literal>F1</literal></para>
@@ -871,11 +871,11 @@
       <sect2 id="resources-keybindings-line_mode">
         <title>Keybinding per la modalità di modifica delle righe</title>
 
-        <para>Usare <userinput>line_mode</userinput> come <replaceable>contesto</replaceable> per definire i keybinding per la modalità di modifica delle righe. I seguenti valori sono validi per il campo <replaceable>azione</replaceable>:</para>
+        <para>Usare <userinput>line-mode</userinput> come <replaceable>contesto</replaceable> per definire i keybinding per la modalità di modifica delle righe. I seguenti valori sono validi per il campo <replaceable>azione</replaceable>:</para>
 
         <variablelist>
           <varlistentry>
-            <term><userinput>enter_align_mode</userinput></term>
+            <term><userinput>enter-align-mode</userinput></term>
             <listitem>
               <para>Passa alla modalità di modifica dell'allineamento</para>
               <para>Predefinito: <literal>space</literal></para>
@@ -883,7 +883,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>enter_character_mode</userinput></term>
+            <term><userinput>enter-character-mode</userinput></term>
             <listitem>
               <para>Passa alla modalità di modifica del testo</para>
               <para>Predefiniti: <literal>Return</literal>, <literal>KP_Enter</literal></para>
@@ -891,7 +891,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>first_line</userinput></term>
+            <term><userinput>first-line</userinput></term>
             <listitem>
               <para>Sposta il cursore alla prima riga</para>
               <para>Predefiniti: <literal>Home</literal>, <literal>g</literal></para>
@@ -899,7 +899,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_first_line</userinput></term>
+            <term><userinput>extend-first-line</userinput></term>
             <listitem>
               <para>Sposta il cursore alla prima riga, estendendo la selezione </para>
               <para>Predefinito: <literal>Shift+Home</literal></para>
@@ -907,7 +907,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>last_line</userinput></term>
+            <term><userinput>last-line</userinput></term>
             <listitem>
               <para>Sposta il cursore all'ultima riga</para>
               <para>Predefiniti: <literal>End</literal>, <literal>Shift+G</literal></para>
@@ -915,7 +915,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_last_line</userinput></term>
+            <term><userinput>extend-last-line</userinput></term>
             <listitem>
               <para>Sposta il cursore all'ultima riga, estendendo la selezione</para>
               <para>Predefinito: <literal>Shift+End</literal></para>
@@ -931,7 +931,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_up</userinput></term>
+            <term><userinput>extend-up</userinput></term>
             <listitem>
               <para>Sposta il cursore alla riga superiore, estendendo la selezione</para>
               <para>Predefiniti: <literal>Shift+Up</literal>, <literal>Shift+K</literal></para>
@@ -947,7 +947,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_down</userinput></term>
+            <term><userinput>extend-down</userinput></term>
             <listitem>
               <para>Sposta il cursore alla riga inferiore, estendendo la selezione</para>
               <para>Predefiniti: <literal>Shift+Down</literal>, <literal>Shift+J</literal></para>
@@ -963,7 +963,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_left</userinput></term>
+            <term><userinput>extend-left</userinput></term>
             <listitem>
               <para>Sposta il cursore a sinistra di un file, estendendo la selezione</para>
               <para>Predefinito: <literal>Shift+Left</literal></para>
@@ -979,7 +979,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_right</userinput></term>
+            <term><userinput>extend-right</userinput></term>
             <listitem>
               <para>Sposta il cursore a destra di un file, estendendo la selezione</para>
               <para>Predefinito: <literal>Shift+Right</literal></para>
@@ -987,7 +987,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>page_up</userinput></term>
+            <term><userinput>page-up</userinput></term>
             <listitem>
               <para>Sposta il cursore alla pagina superiore</para>
               <para>Predefiniti: <literal>Page_Up</literal>, <literal>Ctrl+u</literal></para>
@@ -995,7 +995,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_page_up</userinput></term>
+            <term><userinput>extend-page-up</userinput></term>
             <listitem>
               <para>Sposta il cursore alla pagina superiore, estendendo la selezione</para>
               <para>Predefiniti: <literal>Shift+Page_Up</literal>, <literal>Shift+Ctrl+u</literal></para>
@@ -1003,7 +1003,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>page_down</userinput></term>
+            <term><userinput>page-down</userinput></term>
             <listitem>
               <para>Sposta il cursore alla pagina inferiore</para>
               <para>Predefiniti: <literal>Page_Down</literal>, <literal>Ctrl+d</literal></para>
@@ -1011,7 +1011,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_page_down</userinput></term>
+            <term><userinput>extend-page-down</userinput></term>
             <listitem>
               <para>Sposta il cursore alla pagina inferiore, estendendo la selezione</para>
               <para>Predefiniti: <literal>Shift+Page_Down</literal>, <literal>Shift+Ctrl+d</literal></para>
@@ -1019,7 +1019,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>delete_text</userinput></term>
+            <term><userinput>delete-text</userinput></term>
             <listitem>
               <para>Cancella il testo selezionato</para>
               <para>Predefiniti: <literal>BackSpace</literal>, <literal>Delete</literal>, <literal>x</literal></para>
@@ -1027,7 +1027,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>first_difference</userinput></term>
+            <term><userinput>first-difference</userinput></term>
             <listitem>
               <para>Seleziona la prima differenza</para>
               <para>Predefiniti: <literal>Ctrl+Home</literal>, <literal>Shift+P</literal></para>
@@ -1035,7 +1035,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>previous_difference</userinput></term>
+            <term><userinput>previous-difference</userinput></term>
             <listitem>
               <para>Seleziona la differenza precedente</para>
               <para>Predefinito: <literal>p</literal></para>
@@ -1043,7 +1043,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>next_difference</userinput></term>
+            <term><userinput>next-difference</userinput></term>
             <listitem>
               <para>Seleziona la differenza successiva</para>
               <para>Predefinito: <literal>n</literal></para>
@@ -1051,7 +1051,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>last_difference</userinput></term>
+            <term><userinput>last-difference</userinput></term>
             <listitem>
               <para>Seleziona l'ultima differenza</para>
               <para>Predefiniti: <literal>Ctrl+End</literal>, <literal>Shift+N</literal></para>
@@ -1059,7 +1059,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>clear_edits</userinput></term>
+            <term><userinput>clear-edits</userinput></term>
             <listitem>
               <para>Annulla tutte le modifiche alle righe selezionate</para>
               <para>Predefinito: <literal>r</literal></para>
@@ -1067,7 +1067,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_selection_left</userinput></term>
+            <term><userinput>copy-selection-left</userinput></term>
             <listitem>
               <para>Copia le righe selezionate nel file di sinistra</para>
               <para>Predefinito: Nessuno</para>
@@ -1075,7 +1075,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_selection_right</userinput></term>
+            <term><userinput>copy-selection-right</userinput></term>
             <listitem>
               <para>Copia le righe selezionate nel file di destra</para>
               <para>Predefinito: Nessuno</para>
@@ -1083,7 +1083,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_left_into_selection</userinput></term>
+            <term><userinput>copy-left-into-selection</userinput></term>
             <listitem>
               <para>Copia le righe dal file a sinistra nella selezione</para>
               <para>Predefinito: <literal>Shift+L</literal></para>
@@ -1091,7 +1091,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_right_into_selection</userinput></term>
+            <term><userinput>copy-right-into-selection</userinput></term>
             <listitem>
               <para>Copia le righe dal file a destra nella selezione</para>
               <para>Predefinito: <literal>Shift+H</literal></para>
@@ -1099,7 +1099,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>merge_from_left_then_right</userinput></term>
+            <term><userinput>merge-from-left-then-right</userinput></term>
             <listitem>
               <para>Unisce le righe dal file a sinistra poi da quello a destra</para>
               <para>Predefinito: <literal>m</literal></para>
@@ -1107,7 +1107,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>merge_from_right_then_left</userinput></term>
+            <term><userinput>merge-from-right-then-left</userinput></term>
             <listitem>
               <para>Unisce le righe dal file a destra poi da quello a sinistra</para>
               <para>Predefinito: <literal>Shift+M</literal></para>
@@ -1127,11 +1127,11 @@
       <sect2 id="resources-keybindings-align_mode">
         <title>Keybinding per la modalità di modifica dell'allineamento</title>
 
-        <para>Usare <userinput>align_mode</userinput> come <replaceable>contesto</replaceable> per definire i keybinding per la modalità di modifica dell'allineamento. I seguenti valori sono validi per il campo <replaceable>azione</replaceable>:</para>
+        <para>Usare <userinput>align-mode</userinput> come <replaceable>contesto</replaceable> per definire i keybinding per la modalità di modifica dell'allineamento. I seguenti valori sono validi per il campo <replaceable>azione</replaceable>:</para>
 
         <variablelist>
           <varlistentry>
-            <term><userinput>enter_line_mode</userinput></term>
+            <term><userinput>enter-line-mode</userinput></term>
             <listitem>
               <para>Passa alla modalità di modifica riga</para>
               <para>Predefinito: <literal>Escape</literal></para>
@@ -1139,7 +1139,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>enter_character_mode</userinput></term>
+            <term><userinput>enter-character-mode</userinput></term>
             <listitem>
               <para>Passa alla modalità di modifica del testo</para>
               <para>Predefiniti: <literal>Return</literal>, <literal>KP_Enter</literal></para>
@@ -1147,7 +1147,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>first_line</userinput></term>
+            <term><userinput>first-line</userinput></term>
             <listitem>
               <para>Sposta il cursore alla prima riga</para>
               <para>Predefinito: <literal>g</literal></para>
@@ -1155,7 +1155,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>last_line</userinput></term>
+            <term><userinput>last-line</userinput></term>
             <listitem>
               <para>Sposta il cursore all'ultima riga</para>
               <para>Predefinito: <literal>Shift+G</literal></para>
@@ -1195,7 +1195,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>page_up</userinput></term>
+            <term><userinput>page-up</userinput></term>
             <listitem>
               <para>Sposta il cursore alla pagina superiore</para>
               <para>Predefiniti: <literal>Page_Up</literal>, <literal>Ctrl+u</literal></para>
@@ -1203,7 +1203,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>page_down</userinput></term>
+            <term><userinput>page-down</userinput></term>
             <listitem>
               <para>Sposta il cursore alla pagina inferiore</para>
               <para>Predefiniti: <literal>Page_Down</literal>, <literal>Ctrl+d</literal></para>
@@ -1223,11 +1223,11 @@
       <sect2 id="resources-keybindings-character_mode">
         <title>Keybinding della modalità di modifica testo</title>
 
-        <para>Usare <userinput>character_mode</userinput> come <replaceable>contesto</replaceable> per definire i keybinding per la modalità di modifica testo. I seguenti valori sono validi per il campo <replaceable>azione</replaceable>:</para>
+        <para>Usare <userinput>character-mode</userinput> come <replaceable>contesto</replaceable> per definire i keybinding per la modalità di modifica testo. I seguenti valori sono validi per il campo <replaceable>azione</replaceable>:</para>
 
         <variablelist>
           <varlistentry>
-            <term><userinput>enter_line_mode</userinput></term>
+            <term><userinput>enter-line-mode</userinput></term>
             <listitem>
               <para>Passa alla modalità di modifica riga</para>
               <para>Predefinito: <literal>Escape</literal></para>

--- a/data/usr/share/gnome/help/diffuse/ru/diffuse.xml
+++ b/data/usr/share/gnome/help/diffuse/ru/diffuse.xml
@@ -658,7 +658,7 @@
 
         <variablelist>
           <varlistentry>
-            <term><userinput>open_file</userinput></term>
+            <term><userinput>open-file</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Файл</guimenu> пункт меню <guimenuitem>Открыть Файл...</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Ctrl+o</literal></para>
@@ -666,7 +666,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>open_file_in_new_tab</userinput></term>
+            <term><userinput>open-file-in-new-tab</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Файл</guimenu><guimenuitem>Открыть Файл в Новой Вкладке...</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Ctrl+t</literal></para>
@@ -674,7 +674,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>open_modified_files</userinput></term>
+            <term><userinput>open-modified-files</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Файл</guimenu><guimenuitem>Открыть Измененные Файлы...</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Shift+Ctrl+O</literal></para>
@@ -682,7 +682,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>open_commit</userinput></term>
+            <term><userinput>open-commit</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Файл</guimenu><guimenuitem>Открыть Зафиксированные...</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Shift+Ctrl+T</literal></para>
@@ -690,7 +690,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>reload_file</userinput></term>
+            <term><userinput>reload-file</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Файл</guimenu><guimenuitem>Перезагрузить Файл</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Shift+Ctrl+R</literal></para>
@@ -698,7 +698,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>save_file</userinput></term>
+            <term><userinput>save-file</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Файл</guimenu><guimenuitem>Сохранить Файл</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Ctrl+s</literal></para>
@@ -706,7 +706,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>save_file_as</userinput></term>
+            <term><userinput>save-file-as</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Файл</guimenu><guimenuitem>Сохранить Файл Как...</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Shift+Ctrl+A</literal></para>
@@ -714,7 +714,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>save_all</userinput></term>
+            <term><userinput>save-all</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Файл</guimenu><guimenuitem>Сохранить Все</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Shift+Ctrl+S</literal></para>
@@ -722,7 +722,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>new_2_way_file_merge</userinput></term>
+            <term><userinput>new-2-way-file-merge</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Файл</guimenu><guimenuitem>Новое 2-Оконное Слияние Файлов</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Ctrl+2</literal></para>
@@ -730,7 +730,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>new_3_way_file_merge</userinput></term>
+            <term><userinput>new-3-way-file-merge</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Файл</guimenu><guimenuitem>Новое 3-Оконное Слияние Файлов</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Ctrl+3</literal></para>
@@ -738,7 +738,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>close_tab</userinput></term>
+            <term><userinput>close-tab</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Файл</guimenu><guimenuitem>Закрыть Вкладку</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Ctrl+w</literal></para>
@@ -746,7 +746,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>undo_close_tab</userinput></term>
+            <term><userinput>undo-close-tab</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Файл</guimenu><guimenuitem>Отменить Закрытие Вкладки</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Shift+Ctrl+w</literal></para>
@@ -802,7 +802,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>select_all</userinput></term>
+            <term><userinput>select-all</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Правка</guimenu><guimenuitem>Выбрать Все</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Ctrl+a</literal></para>
@@ -810,7 +810,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>clear_edits</userinput></term>
+            <term><userinput>clear-edits</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Правка</guimenu><guimenuitem>Очистить Правки</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Ctrl+r</literal></para>
@@ -818,7 +818,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>dismiss_all_edits</userinput></term>
+            <term><userinput>dismiss-all-edits</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Правка</guimenu><guimenuitem>Сбросить Все Правки</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Ctrl+d</literal></para>
@@ -834,7 +834,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>find_next</userinput></term>
+            <term><userinput>find-next</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Правка</guimenu><guimenuitem>Найти Следующее</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Ctrl+g</literal></para>
@@ -842,7 +842,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>find_previous</userinput></term>
+            <term><userinput>find-previous</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Правка</guimenu><guimenuitem>Найти Предыдущее</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Shift+Ctrl+G</literal></para>
@@ -850,7 +850,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>go_to_line</userinput></term>
+            <term><userinput>go-to-line</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Правка</guimenu><guimenuitem>Перейти на Строку...</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Shift+Ctrl+L</literal></para>
@@ -866,7 +866,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>no_syntax_highlighting</userinput></term>
+            <term><userinput>no-syntax-highlighting</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Вид</guimenu><guisubmenu>Подсветка Синтаксиса</guisubmenu><guimenuitem>Нет</guimenuitem></menuchoice></para>
               <para>По умолчанию: Нет</para>
@@ -874,7 +874,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>syntax_highlighting_<replaceable>syntax</replaceable></userinput></term>
+            <term><userinput>syntax-highlighting-<replaceable>syntax</replaceable></userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Вид</guimenu><guisubmenu>Подсветка Синтаксиса</guisubmenu><guimenuitem><replaceable>syntax</replaceable></guimenuitem></menuchoice></para>
               <para>По умолчанию: Нет</para>
@@ -882,7 +882,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>realign_all</userinput></term>
+            <term><userinput>realign-all</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Вид</guimenu><guimenuitem>Перестроить Все</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Ctrl+l</literal></para>
@@ -898,7 +898,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>first_difference</userinput></term>
+            <term><userinput>first-difference</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Вид</guimenu><guimenuitem>Первое Различие</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Shift+Ctrl+Up</literal></para>
@@ -906,7 +906,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>previous_difference</userinput></term>
+            <term><userinput>previous-difference</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Вид</guimenu><guimenuitem>Предыдущее Различие</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Ctrl+Up</literal></para>
@@ -914,7 +914,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>next_difference</userinput></term>
+            <term><userinput>next-difference</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Вид</guimenu><guimenuitem>Следующее Различие</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Ctrl+Down</literal></para>
@@ -922,7 +922,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>last_difference</userinput></term>
+            <term><userinput>last-difference</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Вид</guimenu><guimenuitem>Последнее Различие</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Shift+Ctrl+Down</literal></para>
@@ -930,7 +930,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>first_tab</userinput></term>
+            <term><userinput>first-tab</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Вид</guimenu><guimenuitem>Первая Вкладка</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Shift+Ctrl+Page_Up</literal></para>
@@ -938,7 +938,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>previous_tab</userinput></term>
+            <term><userinput>previous-tab</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Вид</guimenu><guimenuitem>Предыдущая Вкладка</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Ctrl+Page_Up</literal></para>
@@ -946,7 +946,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>next_tab</userinput></term>
+            <term><userinput>next-tab</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Вид</guimenu><guimenuitem>Следующая Вкладка</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Ctrl+Page_Down</literal></para>
@@ -954,7 +954,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>last_tab</userinput></term>
+            <term><userinput>last-tab</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Вид</guimenu><guimenuitem>Последняя Вкладка</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Shift+Ctrl+Page_Down</literal></para>
@@ -962,7 +962,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>shift_pane_right</userinput></term>
+            <term><userinput>shift-pane-right</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Вид</guimenu><guimenuitem>Переместить Субокно Вправо</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Shift+Ctrl+parenleft</literal></para>
@@ -970,7 +970,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>shift_pane_left</userinput></term>
+            <term><userinput>shift-pane-left</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Вид</guimenu><guimenuitem>сместить выбранное субокно влево</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Shift+Ctrl+parenright</literal></para>
@@ -978,7 +978,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>convert_to_upper_case</userinput></term>
+            <term><userinput>convert-to-upper-case</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Формат</guimenu><guimenuitem>Преобразовать в Верхний Регистр</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Ctrl+u</literal></para>
@@ -986,7 +986,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>convert_to_lower_case</userinput></term>
+            <term><userinput>convert-to-lower-case</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Формат</guimenu><guimenuitem>Преобразовать в Нижний Регистр</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Shift+Ctrl+U</literal></para>
@@ -994,7 +994,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>sort_lines_in_ascending_order</userinput></term>
+            <term><userinput>sort-lines-in-ascending-order</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Формат</guimenu><guimenuitem>Сортировать Строки в Порядке Возрастания</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Ctrl+y</literal></para>
@@ -1002,7 +1002,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>sort_lines_in_descending_order</userinput></term>
+            <term><userinput>sort-lines-in-descending-order</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Формат</guimenu><guimenuitem>Сортировать Строки в Порядке Убывания</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Shift+Ctrl+Y</literal></para>
@@ -1010,7 +1010,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>remove_trailing_white_space</userinput></term>
+            <term><userinput>remove-trailing-white-space</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Формат</guimenu><guimenuitem>Удалить Замыкающие Пробелы</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Ctrl+k</literal></para>
@@ -1018,7 +1018,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>convert_tabs_to_spaces</userinput></term>
+            <term><userinput>convert-tabs-to-spaces</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Формат</guimenu><guimenuitem>Преобразовать Табуляторы в Пробелы</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Ctrl+b</literal></para>
@@ -1026,7 +1026,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>convert_leading_spaces_to_tabs</userinput></term>
+            <term><userinput>convert-leading-spaces-to-tabs</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Формат</guimenu><guimenuitem>Преобразовать Вводные Пробелы в Табуляторы</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Shift+Ctrl+B</literal></para>
@@ -1034,7 +1034,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>increase_indenting</userinput></term>
+            <term><userinput>increase-indenting</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Формат</guimenu><guimenuitem>Увеличить Отступ</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Shift+Ctrl+greater</literal></para>
@@ -1042,7 +1042,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>decrease_indenting</userinput></term>
+            <term><userinput>decrease-indenting</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Формат</guimenu><guimenuitem>Уменьшить Отступ</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Shift+Ctrl+less</literal></para>
@@ -1050,7 +1050,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>convert_to_dos</userinput></term>
+            <term><userinput>convert-to-dos</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Формат</guimenu><guimenuitem>Преобразовать в DOS Формат</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Shift+Ctrl+E</literal></para>
@@ -1058,7 +1058,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>convert_to_mac</userinput></term>
+            <term><userinput>convert-to-mac</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Формат</guimenu><guimenuitem>Преобразовать в Maс Формат</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Shift+Ctrl+C</literal></para>
@@ -1066,7 +1066,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>convert_to_unix</userinput></term>
+            <term><userinput>convert-to-unix</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Формат</guimenu><guimenuitem>Преобразовать в Uniх Формат</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Ctrl+e</literal></para>
@@ -1074,7 +1074,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_selection_right</userinput></term>
+            <term><userinput>copy-selection-right</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Слияние</guimenu><guimenuitem>Копировать Выборку Вправо</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Shift+Ctrl+Right</literal></para>
@@ -1082,7 +1082,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_selection_left</userinput></term>
+            <term><userinput>copy-selection-left</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Слияние</guimenu><guimenuitem>Копировать Выборку Влево</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Shift+Ctrl+Left</literal></para>
@@ -1090,7 +1090,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_left_into_selection</userinput></term>
+            <term><userinput>copy-left-into-selection</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Слияние</guimenu><guimenuitem>Копировать Слева в Выборку</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Ctrl+Right</literal></para>
@@ -1098,7 +1098,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_right_into_selection</userinput></term>
+            <term><userinput>copy-right-into-selection</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Слияние</guimenu><guimenuitem>Копировать Справа в Выборку</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Ctrl+Left</literal></para>
@@ -1106,7 +1106,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>merge_from_left_then_right</userinput></term>
+            <term><userinput>merge-from-left-then-right</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Слияние</guimenu><guimenuitem>Слияние Слева Затем Справа</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Ctrl+m</literal></para>
@@ -1114,7 +1114,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>merge_from_right_then_left</userinput></term>
+            <term><userinput>merge-from-right-then-left</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Слияние</guimenu><guimenuitem>Слияние Справа Затем Слева</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>Shift+Ctrl+M</literal></para>
@@ -1122,7 +1122,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>help_contents</userinput></term>
+            <term><userinput>help-contents</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Справка</guimenu><guimenuitem>Содержание Справки...</guimenuitem></menuchoice></para>
               <para>По умолчанию: <literal>F1</literal></para>
@@ -1143,7 +1143,7 @@
         <title>Привязки Клавиш Режима Редактирования Строк</title>
 
         <para>
-          Используйте <userinput>line_mode</userinput> для
+          Используйте <userinput>line-mode</userinput> для
           <replaceable>context</replaceable>, чтобы определить привязки клавиш
           для режима редактирования строк. Следующие значения допустимы для
           <replaceable>action</replaceable>:
@@ -1151,7 +1151,7 @@
 
         <variablelist>
           <varlistentry>
-            <term><userinput>enter_align_mode</userinput></term>
+            <term><userinput>enter-align-mode</userinput></term>
             <listitem>
               <para>ввести режим редактирования выравнивания</para>
               <para>По умолчанию: <literal>space</literal></para>
@@ -1159,7 +1159,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>enter_character_mode</userinput></term>
+            <term><userinput>enter-character-mode</userinput></term>
             <listitem>
               <para>ввести режим редактирования символов</para>
               <para>По умолчаниям: <literal>Return</literal>, <literal>KP_Enter</literal></para>
@@ -1167,7 +1167,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>first_line</userinput></term>
+            <term><userinput>first-line</userinput></term>
             <listitem>
               <para>переместить курсор на первую строку</para>
               <para>По умолчаниям: <literal>Home</literal>, <literal>g</literal></para>
@@ -1175,7 +1175,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_first_line</userinput></term>
+            <term><userinput>extend-first-line</userinput></term>
             <listitem>
               <para>переместить курсор на первую строку, расширение выборки</para>
               <para>По умолчанию: <literal>Shift+Home</literal></para>
@@ -1183,7 +1183,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>last_line</userinput></term>
+            <term><userinput>last-line</userinput></term>
             <listitem>
               <para>переместить курсор на последнюю строку</para>
               <para>По умолчаниям: <literal>End</literal>, <literal>Shift+G</literal></para>
@@ -1191,7 +1191,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_last_line</userinput></term>
+            <term><userinput>extend-last-line</userinput></term>
             <listitem>
               <para>переместить курсор на последнюю строку, расширение выборки</para>
               <para>По умолчанию: <literal>Shift+End</literal></para>
@@ -1207,7 +1207,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_up</userinput></term>
+            <term><userinput>extend-up</userinput></term>
             <listitem>
               <para>переместить курсор на одну строку вверх, расширение выборки</para>
               <para>По умолчаниям: <literal>Shift+Up</literal>, <literal>Shift+K</literal></para>
@@ -1223,7 +1223,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_down</userinput></term>
+            <term><userinput>extend-down</userinput></term>
             <listitem>
               <para>переместить курсор на одну строку вниз, расширение выборки</para>
               <para>По умолчаниям: <literal>Shift+Down</literal>, <literal>Shift+J</literal></para>
@@ -1239,7 +1239,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_left</userinput></term>
+            <term><userinput>extend-left</userinput></term>
             <listitem>
               <para>переместить курсор влево на один файл, расширение выборки</para>
               <para>По умолчанию: <literal>Shift+Left</literal></para>
@@ -1255,7 +1255,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_right</userinput></term>
+            <term><userinput>extend-right</userinput></term>
             <listitem>
               <para>переместить курсор вправо на один файл, расширение выборки</para>
               <para>По умолчанию: <literal>Shift+Right</literal></para>
@@ -1263,7 +1263,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>page_up</userinput></term>
+            <term><userinput>page-up</userinput></term>
             <listitem>
               <para>переместить курсор на одну страницу вверх</para>
               <para>По умолчаниям: <literal>Page_Up</literal>, <literal>Ctrl+u</literal></para>
@@ -1271,7 +1271,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_page_up</userinput></term>
+            <term><userinput>extend-page-up</userinput></term>
             <listitem>
               <para>переместить курсор на одну страницу вверх, расширение выборки</para>
               <para>По умолчаниям: <literal>Shift+Page_Up</literal>, <literal>Shift+Ctrl+u</literal></para>
@@ -1279,7 +1279,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>page_down</userinput></term>
+            <term><userinput>page-down</userinput></term>
             <listitem>
               <para>переместить курсор на одну страницу вниз</para>
               <para>По умолчаниям: <literal>Page_Down</literal>, <literal>Ctrl+d</literal></para>
@@ -1287,7 +1287,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>extend_page_down</userinput></term>
+            <term><userinput>extend-page-down</userinput></term>
             <listitem>
               <para>переместить курсор на одну страницу вниз, расширение выборки</para>
               <para>По умолчаниям: <literal>Shift+Page_Down</literal>, <literal>Shift+Ctrl+d</literal></para>
@@ -1295,7 +1295,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>delete_text</userinput></term>
+            <term><userinput>delete-text</userinput></term>
             <listitem>
               <para>удалить выбранный текст</para>
               <para>По умолчаниям: <literal>BackSpace</literal>, <literal>Delete</literal>, <literal>x</literal></para>
@@ -1303,7 +1303,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>first_difference</userinput></term>
+            <term><userinput>first-difference</userinput></term>
             <listitem>
               <para>выбрать первое различие</para>
               <para>По умолчаниям: <literal>Ctrl+Home</literal>, <literal>Shift+P</literal></para>
@@ -1311,7 +1311,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>previous_difference</userinput></term>
+            <term><userinput>previous-difference</userinput></term>
             <listitem>
               <para>выбрать предыдущее различие</para>
               <para>По умолчанию: <literal>p</literal></para>
@@ -1319,7 +1319,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>next_difference</userinput></term>
+            <term><userinput>next-difference</userinput></term>
             <listitem>
               <para>выбрать следующее различие</para>
               <para>По умолчанию: <literal>n</literal></para>
@@ -1327,7 +1327,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>last_difference</userinput></term>
+            <term><userinput>last-difference</userinput></term>
             <listitem>
               <para>выбрать последнее различие</para>
               <para>По умолчаниям: <literal>Ctrl+End</literal>, <literal>Shift+N</literal></para>
@@ -1335,7 +1335,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>clear_edits</userinput></term>
+            <term><userinput>clear-edits</userinput></term>
             <listitem>
               <para>очистить все редактирования в выбранных строках</para>
               <para>По умолчанию: <literal>r</literal></para>
@@ -1343,7 +1343,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_selection_right</userinput></term>
+            <term><userinput>copy-selection-right</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Слияние</guimenu><guimenuitem>Копировать Выборку Вправо</guimenuitem></menuchoice></para>
               <para>По умолчанию: Нет</para>
@@ -1351,7 +1351,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_selection_left</userinput></term>
+            <term><userinput>copy-selection-left</userinput></term>
             <listitem>
               <para><menuchoice><guimenu>Слияние</guimenu><guimenuitem>Копировать Выборку Влево</guimenuitem></menuchoice></para>
               <para>По умолчанию: Нет</para>
@@ -1359,7 +1359,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_left_into_selection</userinput></term>
+            <term><userinput>copy-left-into-selection</userinput></term>
             <listitem>
               <para>копировать строки из файла слева в выборку</para>
               <para>По умолчанию: <literal>Shift+L</literal></para>
@@ -1367,7 +1367,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>copy_right_into_selection</userinput></term>
+            <term><userinput>copy-right-into-selection</userinput></term>
             <listitem>
               <para>копировать строки из файла справа в выборку</para>
               <para>По умолчанию: <literal>Shift+H</literal></para>
@@ -1375,7 +1375,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>merge_from_left_then_right</userinput></term>
+            <term><userinput>merge-from-left-then-right</userinput></term>
             <listitem>
               <para>объединить строки из файла слева, затем из файла справа</para>
               <para>По умолчанию: <literal>m</literal></para>
@@ -1383,7 +1383,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>merge_from_right_then_left</userinput></term>
+            <term><userinput>merge-from-right-then-left</userinput></term>
             <listitem>
               <para>объединить строки из файла справа, затем из файла слева</para>
               <para>По умолчанию: <literal>Shift+M</literal></para>
@@ -1404,7 +1404,7 @@
         <title>Привязки Клавиш Режима Редактирования Выравнивания</title>
 
         <para>
-          Используйте <userinput>align_mode</userinput> для
+          Используйте <userinput>align-mode</userinput> для
           <replaceable>context</replaceable>, чтобы определить привязки клавиш
           для режима редактирования выравнивания. Следующие значения допустимы
           для <replaceable>action</replaceable>:
@@ -1412,7 +1412,7 @@
 
         <variablelist>
           <varlistentry>
-            <term><userinput>enter_line_mode</userinput></term>
+            <term><userinput>enter-line-mode</userinput></term>
             <listitem>
               <para>ввести режим редактирования строк</para>
               <para>По умолчанию: <literal>Escape</literal></para>
@@ -1420,7 +1420,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>enter_character_mode</userinput></term>
+            <term><userinput>enter-character-mode</userinput></term>
             <listitem>
               <para>ввести режим редактирования символов</para>
               <para>По умолчаниям: <literal>Return</literal>, <literal>KP_Enter</literal></para>
@@ -1428,7 +1428,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>first_line</userinput></term>
+            <term><userinput>first-line</userinput></term>
             <listitem>
               <para>переместить курсор на первую строку</para>
               <para>По умолчанию: <literal>g</literal></para>
@@ -1436,7 +1436,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>last_line</userinput></term>
+            <term><userinput>last-line</userinput></term>
             <listitem>
               <para>переместить курсор на последнюю строку</para>
               <para>По умолчанию: <literal>Shift+G</literal></para>
@@ -1476,7 +1476,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>page_up</userinput></term>
+            <term><userinput>page-up</userinput></term>
             <listitem>
               <para>переместить курсор на одну страницу вверх</para>
               <para>По умолчаниям: <literal>Page_Up</literal>, <literal>Ctrl+u</literal></para>
@@ -1484,7 +1484,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term><userinput>page_down</userinput></term>
+            <term><userinput>page-down</userinput></term>
             <listitem>
               <para>переместить курсор на одну страницу вниз</para>
               <para>По умолчаниям: <literal>Page_Down</literal>, <literal>Ctrl+d</literal></para>
@@ -1505,7 +1505,7 @@
         <title>Привязки Клавиш Режима Редактирования Символов</title>
 
         <para>
-          Используйте <userinput>character_mode</userinput> для
+          Используйте <userinput>character-mode</userinput> для
           <replaceable>context</replaceable>, чтобы определить привязки клавиш
           для режима редактирования символов. Следующие значения допустимы для
           <replaceable>action</replaceable>:
@@ -1513,7 +1513,7 @@
 
         <variablelist>
           <varlistentry>
-            <term><userinput>enter_line_mode</userinput></term>
+            <term><userinput>enter-line-mode</userinput></term>
             <listitem>
               <para>ввести режим редактирования строк</para>
               <para>По умолчанию: <literal>Escape</literal></para>

--- a/src/diffuse/resources.py
+++ b/src/diffuse/resources.py
@@ -47,117 +47,117 @@ class Resources:
         defaultModKey = 'Cmd+' if platform.system() == 'Darwin' else 'Ctrl+'
         self.keybindings = {}
         self.keybindings_lookup = {}
-        self.setKeyBinding('menu', 'open_file', defaultModKey + 'o')
-        self.setKeyBinding('menu', 'open_file_in_new_tab', defaultModKey + 't')
-        self.setKeyBinding('menu', 'open_modified_files', 'Shift+Ctrl+O')
-        self.setKeyBinding('menu', 'open_commit', 'Shift+Ctrl+T')
-        self.setKeyBinding('menu', 'reload_file', 'Shift+Ctrl+R')
-        self.setKeyBinding('menu', 'save_file', defaultModKey + 's')
-        self.setKeyBinding('menu', 'save_file_as', defaultModKey + 'Shift+A')
-        self.setKeyBinding('menu', 'save_all', defaultModKey + 'Shift+S')
-        self.setKeyBinding('menu', 'new_2_way_file_merge', 'Ctrl+2')
-        self.setKeyBinding('menu', 'new_3_way_file_merge', 'Ctrl+3')
-        self.setKeyBinding('menu', 'new_n_way_file_merge', 'Ctrl+4')
-        self.setKeyBinding('menu', 'close_tab', defaultModKey + 'w')
-        self.setKeyBinding('menu', 'undo_close_tab', defaultModKey + 'Shift+W')
+        self.setKeyBinding('menu', 'open-file', defaultModKey + 'o')
+        self.setKeyBinding('menu', 'open-file-in-new-tab', defaultModKey + 't')
+        self.setKeyBinding('menu', 'open-modified-files', 'Shift+Ctrl+O')
+        self.setKeyBinding('menu', 'open-commit', 'Shift+Ctrl+T')
+        self.setKeyBinding('menu', 'reload-file', 'Shift+Ctrl+R')
+        self.setKeyBinding('menu', 'save-file', defaultModKey + 's')
+        self.setKeyBinding('menu', 'save-file-as', defaultModKey + 'Shift+A')
+        self.setKeyBinding('menu', 'save-all', defaultModKey + 'Shift+S')
+        self.setKeyBinding('menu', 'new-2-way-file-merge', 'Ctrl+2')
+        self.setKeyBinding('menu', 'new-3-way-file-merge', 'Ctrl+3')
+        self.setKeyBinding('menu', 'new-n-way-file-merge', 'Ctrl+4')
+        self.setKeyBinding('menu', 'close-tab', defaultModKey + 'w')
+        self.setKeyBinding('menu', 'undo-close-tab', defaultModKey + 'Shift+W')
         self.setKeyBinding('menu', 'quit', defaultModKey + 'q')
         self.setKeyBinding('menu', 'undo', defaultModKey + 'z')
         self.setKeyBinding('menu', 'redo', defaultModKey + 'Shift+Z')
         self.setKeyBinding('menu', 'cut', defaultModKey + 'x')
         self.setKeyBinding('menu', 'copy', defaultModKey + 'c')
         self.setKeyBinding('menu', 'paste', defaultModKey + 'v')
-        self.setKeyBinding('menu', 'select_all', defaultModKey + 'a')
-        self.setKeyBinding('menu', 'clear_edits', defaultModKey + 'r')
-        self.setKeyBinding('menu', 'dismiss_all_edits', defaultModKey + 'd')
+        self.setKeyBinding('menu', 'select-all', defaultModKey + 'a')
+        self.setKeyBinding('menu', 'clear-edits', defaultModKey + 'r')
+        self.setKeyBinding('menu', 'dismiss-all-edits', defaultModKey + 'd')
         self.setKeyBinding('menu', 'find', defaultModKey + 'f')
-        self.setKeyBinding('menu', 'find_next', defaultModKey + 'g')
-        self.setKeyBinding('menu', 'find_previous', defaultModKey + 'Shift+G')
-        self.setKeyBinding('menu', 'go_to_line', defaultModKey + 'Shift+l')
-        self.setKeyBinding('menu', 'realign_all', defaultModKey + 'l')
+        self.setKeyBinding('menu', 'find-next', defaultModKey + 'g')
+        self.setKeyBinding('menu', 'find-previous', defaultModKey + 'Shift+G')
+        self.setKeyBinding('menu', 'go-to-line', defaultModKey + 'Shift+l')
+        self.setKeyBinding('menu', 'realign-all', defaultModKey + 'l')
         self.setKeyBinding('menu', 'isolate', defaultModKey + 'i')
-        self.setKeyBinding('menu', 'first_difference', defaultModKey + 'Shift+Up')
-        self.setKeyBinding('menu', 'previous_difference', defaultModKey + 'Up')
-        self.setKeyBinding('menu', 'next_difference', defaultModKey + 'Down')
-        self.setKeyBinding('menu', 'last_difference', defaultModKey + 'Shift+Down')
-        self.setKeyBinding('menu', 'first_tab', 'Shift+Ctrl+Page_Up')
-        self.setKeyBinding('menu', 'previous_tab', 'Ctrl+Page_Up')
-        self.setKeyBinding('menu', 'next_tab', 'Ctrl+Page_Down')
-        self.setKeyBinding('menu', 'last_tab', 'Shift+Ctrl+Page_Down')
-        self.setKeyBinding('menu', 'shift_pane_right', 'Shift+Ctrl+parenright')
-        self.setKeyBinding('menu', 'shift_pane_left', 'Shift+Ctrl+parenleft')
-        self.setKeyBinding('menu', 'convert_to_upper_case', defaultModKey + 'u')
-        self.setKeyBinding('menu', 'convert_to_lower_case', defaultModKey + 'Shift+U')
-        self.setKeyBinding('menu', 'sort_lines_in_ascending_order', defaultModKey + 'y')
-        self.setKeyBinding('menu', 'sort_lines_in_descending_order', defaultModKey + 'Shift+Y')
-        self.setKeyBinding('menu', 'remove_trailing_white_space', defaultModKey + 'k')
-        self.setKeyBinding('menu', 'convert_tabs_to_spaces', defaultModKey + 'b')
-        self.setKeyBinding('menu', 'convert_leading_spaces_to_tabs', 'Shift+Ctrl+B')
-        self.setKeyBinding('menu', 'increase_indenting', defaultModKey + 'Shift+greater')
-        self.setKeyBinding('menu', 'decrease_indenting', defaultModKey + 'Shift+less')
-        self.setKeyBinding('menu', 'convert_to_dos', defaultModKey + 'Shift+E')
-        self.setKeyBinding('menu', 'convert_to_mac', defaultModKey + 'Shift+C')
-        self.setKeyBinding('menu', 'convert_to_unix', defaultModKey + 'e')
-        self.setKeyBinding('menu', 'copy_selection_right', defaultModKey + 'Shift+Right')
-        self.setKeyBinding('menu', 'copy_selection_left', defaultModKey + 'Shift+Left')
-        self.setKeyBinding('menu', 'copy_left_into_selection', defaultModKey + 'Right')
-        self.setKeyBinding('menu', 'copy_right_into_selection', defaultModKey + 'Left')
-        self.setKeyBinding('menu', 'merge_from_left_then_right', defaultModKey + 'm')
-        self.setKeyBinding('menu', 'merge_from_right_then_left', defaultModKey + 'Shift+M')
-        self.setKeyBinding('menu', 'help_contents', 'F1')
-        self.setKeyBinding('line_mode', 'enter_align_mode', 'space')
-        self.setKeyBinding('line_mode', 'enter_character_mode', 'Return')
-        self.setKeyBinding('line_mode', 'enter_character_mode', 'KP_Enter')
-        self.setKeyBinding('line_mode', 'first_line', 'Home')
-        self.setKeyBinding('line_mode', 'first_line', 'g')
-        self.setKeyBinding('line_mode', 'extend_first_line', 'Shift+Home')
-        self.setKeyBinding('line_mode', 'last_line', 'End')
-        self.setKeyBinding('line_mode', 'last_line', 'Shift+G')
-        self.setKeyBinding('line_mode', 'extend_last_line', 'Shift+End')
+        self.setKeyBinding('menu', 'first-difference', defaultModKey + 'Shift+Up')
+        self.setKeyBinding('menu', 'previous-difference', defaultModKey + 'Up')
+        self.setKeyBinding('menu', 'next-difference', defaultModKey + 'Down')
+        self.setKeyBinding('menu', 'last-difference', defaultModKey + 'Shift+Down')
+        self.setKeyBinding('menu', 'first-tab', 'Shift+Ctrl+Page_Up')
+        self.setKeyBinding('menu', 'previous-tab', 'Ctrl+Page_Up')
+        self.setKeyBinding('menu', 'next-tab', 'Ctrl+Page_Down')
+        self.setKeyBinding('menu', 'last-tab', 'Shift+Ctrl+Page_Down')
+        self.setKeyBinding('menu', 'shift-pane-right', 'Shift+Ctrl+parenright')
+        self.setKeyBinding('menu', 'shift-pane-left', 'Shift+Ctrl+parenleft')
+        self.setKeyBinding('menu', 'convert-to-upper-case', defaultModKey + 'u')
+        self.setKeyBinding('menu', 'convert-to-lower-case', defaultModKey + 'Shift+U')
+        self.setKeyBinding('menu', 'sort-lines-in-ascending-order', defaultModKey + 'y')
+        self.setKeyBinding('menu', 'sort-lines-in-descending-order', defaultModKey + 'Shift+Y')
+        self.setKeyBinding('menu', 'remove-trailing-white-space', defaultModKey + 'k')
+        self.setKeyBinding('menu', 'convert-tabs-to-spaces', defaultModKey + 'b')
+        self.setKeyBinding('menu', 'convert-leading-spaces-to-tabs', 'Shift+Ctrl+B')
+        self.setKeyBinding('menu', 'increase-indenting', defaultModKey + 'Shift+greater')
+        self.setKeyBinding('menu', 'decrease-indenting', defaultModKey + 'Shift+less')
+        self.setKeyBinding('menu', 'convert-to-dos', defaultModKey + 'Shift+E')
+        self.setKeyBinding('menu', 'convert-to-mac', defaultModKey + 'Shift+C')
+        self.setKeyBinding('menu', 'convert-to-unix', defaultModKey + 'e')
+        self.setKeyBinding('menu', 'copy-selection-right', defaultModKey + 'Shift+Right')
+        self.setKeyBinding('menu', 'copy-selection-left', defaultModKey + 'Shift+Left')
+        self.setKeyBinding('menu', 'copy-left-into-selection', defaultModKey + 'Right')
+        self.setKeyBinding('menu', 'copy-right-into-selection', defaultModKey + 'Left')
+        self.setKeyBinding('menu', 'merge-from-left-then-right', defaultModKey + 'm')
+        self.setKeyBinding('menu', 'merge-from-right-then-left', defaultModKey + 'Shift+M')
+        self.setKeyBinding('menu', 'help-contents', 'F1')
+        self.setKeyBinding('line_mode', 'enter-align-mode', 'space')
+        self.setKeyBinding('line_mode', 'enter-character-mode', 'Return')
+        self.setKeyBinding('line_mode', 'enter-character-mode', 'KP_Enter')
+        self.setKeyBinding('line_mode', 'first-line', 'Home')
+        self.setKeyBinding('line_mode', 'first-line', 'g')
+        self.setKeyBinding('line_mode', 'extend-first-line', 'Shift+Home')
+        self.setKeyBinding('line_mode', 'last-line', 'End')
+        self.setKeyBinding('line_mode', 'last-line', 'Shift+G')
+        self.setKeyBinding('line_mode', 'extend-last-line', 'Shift+End')
         self.setKeyBinding('line_mode', 'up', 'Up')
         self.setKeyBinding('line_mode', 'up', 'k')
-        self.setKeyBinding('line_mode', 'extend_up', 'Shift+Up')
-        self.setKeyBinding('line_mode', 'extend_up', 'Shift+K')
+        self.setKeyBinding('line_mode', 'extend-up', 'Shift+Up')
+        self.setKeyBinding('line_mode', 'extend-up', 'Shift+K')
         self.setKeyBinding('line_mode', 'down', 'Down')
         self.setKeyBinding('line_mode', 'down', 'j')
-        self.setKeyBinding('line_mode', 'extend_down', 'Shift+Down')
-        self.setKeyBinding('line_mode', 'extend_down', 'Shift+J')
+        self.setKeyBinding('line_mode', 'extend-down', 'Shift+Down')
+        self.setKeyBinding('line_mode', 'extend-down', 'Shift+J')
         self.setKeyBinding('line_mode', 'left', 'Left')
         self.setKeyBinding('line_mode', 'left', 'h')
-        self.setKeyBinding('line_mode', 'extend_left', 'Shift+Left')
+        self.setKeyBinding('line_mode', 'extend-left', 'Shift+Left')
         self.setKeyBinding('line_mode', 'right', 'Right')
         self.setKeyBinding('line_mode', 'right', 'l')
-        self.setKeyBinding('line_mode', 'extend_right', 'Shift+Right')
-        self.setKeyBinding('line_mode', 'page_up', 'Page_Up')
-        self.setKeyBinding('line_mode', 'page_up', defaultModKey + 'u')
-        self.setKeyBinding('line_mode', 'extend_page_up', 'Shift+Page_Up')
-        self.setKeyBinding('line_mode', 'extend_page_up', defaultModKey + 'Shift+U')
-        self.setKeyBinding('line_mode', 'page_down', 'Page_Down')
-        self.setKeyBinding('line_mode', 'page_down', defaultModKey + 'd')
-        self.setKeyBinding('line_mode', 'extend_page_down', 'Shift+Page_Down')
-        self.setKeyBinding('line_mode', 'extend_page_down', defaultModKey + 'Shift+D')
-        self.setKeyBinding('line_mode', 'delete_text', 'BackSpace')
-        self.setKeyBinding('line_mode', 'delete_text', 'Delete')
-        self.setKeyBinding('line_mode', 'delete_text', 'x')
-        self.setKeyBinding('line_mode', 'clear_edits', 'r')
+        self.setKeyBinding('line_mode', 'extend-right', 'Shift+Right')
+        self.setKeyBinding('line_mode', 'page-up', 'Page_Up')
+        self.setKeyBinding('line_mode', 'page-up', defaultModKey + 'u')
+        self.setKeyBinding('line_mode', 'extend-page-up', 'Shift+Page_Up')
+        self.setKeyBinding('line_mode', 'extend-page-up', defaultModKey + 'Shift+U')
+        self.setKeyBinding('line_mode', 'page-down', 'Page_Down')
+        self.setKeyBinding('line_mode', 'page-down', defaultModKey + 'd')
+        self.setKeyBinding('line_mode', 'extend-page-down', 'Shift+Page_Down')
+        self.setKeyBinding('line_mode', 'extend-page-down', defaultModKey + 'Shift+D')
+        self.setKeyBinding('line_mode', 'delete-text', 'BackSpace')
+        self.setKeyBinding('line_mode', 'delete-text', 'Delete')
+        self.setKeyBinding('line_mode', 'delete-text', 'x')
+        self.setKeyBinding('line_mode', 'clear-edits', 'r')
         self.setKeyBinding('line_mode', 'isolate', 'i')
-        self.setKeyBinding('line_mode', 'first_difference', 'Ctrl+Home')
-        self.setKeyBinding('line_mode', 'first_difference', 'Shift+P')
-        self.setKeyBinding('line_mode', 'previous_difference', 'p')
-        self.setKeyBinding('line_mode', 'next_difference', 'n')
-        self.setKeyBinding('line_mode', 'last_difference', 'Ctrl+End')
-        self.setKeyBinding('line_mode', 'last_difference', 'Shift+N')
-        # self.setKeyBinding('line_mode', 'copy_selection_right', 'Shift+L')
-        # self.setKeyBinding('line_mode', 'copy_selection_left', 'Shift+H')
-        self.setKeyBinding('line_mode', 'copy_left_into_selection', 'Shift+L')
-        self.setKeyBinding('line_mode', 'copy_right_into_selection', 'Shift+H')
-        self.setKeyBinding('line_mode', 'merge_from_left_then_right', 'm')
-        self.setKeyBinding('line_mode', 'merge_from_right_then_left', 'Shift+M')
-        self.setKeyBinding('align_mode', 'enter_line_mode', 'Escape')
+        self.setKeyBinding('line_mode', 'first-difference', 'Ctrl+Home')
+        self.setKeyBinding('line_mode', 'first-difference', 'Shift+P')
+        self.setKeyBinding('line_mode', 'previous-difference', 'p')
+        self.setKeyBinding('line_mode', 'next-difference', 'n')
+        self.setKeyBinding('line_mode', 'last-difference', 'Ctrl+End')
+        self.setKeyBinding('line_mode', 'last-difference', 'Shift+N')
+        # self.setKeyBinding('line_mode', 'copy-selection-right', 'Shift+L')
+        # self.setKeyBinding('line_mode', 'copy-selection-left', 'Shift+H')
+        self.setKeyBinding('line_mode', 'copy-left-into-selection', 'Shift+L')
+        self.setKeyBinding('line_mode', 'copy-right-into-selection', 'Shift+H')
+        self.setKeyBinding('line_mode', 'merge-from-left-then-right', 'm')
+        self.setKeyBinding('line_mode', 'merge-from-right-then-left', 'Shift+M')
+        self.setKeyBinding('align_mode', 'enter-line-mode', 'Escape')
         self.setKeyBinding('align_mode', 'align', 'space')
-        self.setKeyBinding('align_mode', 'enter_character_mode', 'Return')
-        self.setKeyBinding('align_mode', 'enter_character_mode', 'KP_Enter')
-        self.setKeyBinding('align_mode', 'first_line', 'g')
-        self.setKeyBinding('align_mode', 'last_line', 'Shift+G')
+        self.setKeyBinding('align_mode', 'enter-character-mode', 'Return')
+        self.setKeyBinding('align_mode', 'enter-character-mode', 'KP_Enter')
+        self.setKeyBinding('align_mode', 'first-line', 'g')
+        self.setKeyBinding('align_mode', 'last-line', 'Shift+G')
         self.setKeyBinding('align_mode', 'up', 'Up')
         self.setKeyBinding('align_mode', 'up', 'k')
         self.setKeyBinding('align_mode', 'down', 'Down')
@@ -166,11 +166,11 @@ class Resources:
         self.setKeyBinding('align_mode', 'left', 'h')
         self.setKeyBinding('align_mode', 'right', 'Right')
         self.setKeyBinding('align_mode', 'right', 'l')
-        self.setKeyBinding('align_mode', 'page_up', 'Page_Up')
-        self.setKeyBinding('align_mode', 'page_up', defaultModKey + 'u')
-        self.setKeyBinding('align_mode', 'page_down', 'Page_Down')
-        self.setKeyBinding('align_mode', 'page_down', defaultModKey + 'd')
-        self.setKeyBinding('character_mode', 'enter_line_mode', 'Escape')
+        self.setKeyBinding('align_mode', 'page-up', 'Page_Up')
+        self.setKeyBinding('align_mode', 'page-up', defaultModKey + 'u')
+        self.setKeyBinding('align_mode', 'page-down', 'Page_Down')
+        self.setKeyBinding('align_mode', 'page-down', defaultModKey + 'd')
+        self.setKeyBinding('character_mode', 'enter-line-mode', 'Escape')
 
         # default colours
         self.colours: Dict[str, _Colour] = {
@@ -225,29 +225,29 @@ class Resources:
         self.setDifferenceColours('difference_1 difference_2 difference_3')
 
     # keyboard action processing
-    def setKeyBinding(self, ctx: str, s: str, v: str) -> None:
-        action_tuple = (ctx, s)
-        modifiers = Gdk.ModifierType(0)
+    def setKeyBinding(self, ctx: str, name: str, modifiers: str) -> None:
+        action_tuple = (ctx, name)
+        modifier_flags = Gdk.ModifierType(0)
         key = None
-        for token in v.split('+'):
+        for token in modifiers.split('+'):
             if token == 'Shift':
-                modifiers |= Gdk.ModifierType.SHIFT_MASK
+                modifier_flags |= Gdk.ModifierType.SHIFT_MASK
             elif token == 'Ctrl':
-                modifiers |= Gdk.ModifierType.CONTROL_MASK
+                modifier_flags |= Gdk.ModifierType.CONTROL_MASK
             elif token == 'Cmd':
-                modifiers |= Gdk.ModifierType.META_MASK
+                modifier_flags |= Gdk.ModifierType.META_MASK
             elif token == 'Alt':
-                modifiers |= Gdk.ModifierType.MOD1_MASK
+                modifier_flags |= Gdk.ModifierType.MOD1_MASK
             elif len(token) == 0 or token[0] == '_':
-                raise ValueError(_('The key binding "{key}" is invalid').format(key=v))
+                raise ValueError(_('The key binding "{key}" is invalid').format(key=modifiers))
             else:
                 token = 'KEY_' + token
                 if not hasattr(Gdk, token):
-                    raise ValueError(_('The key binding "{key}" is invalid').format(key=v))
+                    raise ValueError(_('The key binding "{key}" is invalid').format(key=modifiers))
                 key = getattr(Gdk, token)
         if key is None:
-            raise ValueError(_('The key binding "{key}" is invalid').format(key=v))
-        key_tuple = (ctx, (key, modifiers))
+            raise ValueError(_('The key binding "{key}" is invalid').format(key=modifiers))
+        key_tuple = (ctx, (key, modifier_flags))
 
         # remove any existing binding
         if key_tuple in self.keybindings_lookup:
@@ -272,17 +272,17 @@ class Resources:
         del self.keybindings_lookup[key_tuple]
         del self.keybindings[action_tuple][key_tuple]
 
+    def getKeyBindings(self, ctx, name):
+        try:
+            return [t for _, t in self.keybindings[(ctx, name)].keys()]
+        except KeyError:
+            return []
+
     def getActionForKey(self, ctx, key, modifiers):
         try:
             return self.keybindings_lookup[(ctx, (key, modifiers))][1]
         except KeyError:
             return None
-
-    def getKeyBindings(self, ctx, s):
-        try:
-            return [t for c, t in self.keybindings[(ctx, s)].keys()]
-        except KeyError:
-            return []
 
     # colours used for indicating differences
     def setDifferenceColours(self, s: str) -> None:

--- a/src/diffuse/widgets.py
+++ b/src/diffuse/widgets.py
@@ -523,8 +523,8 @@ class FileDiffViewerBase(Gtk.Grid):
                 self.align_pane = 0
                 self.align_line = 0
             self.mode = EditMode.LINE
-            self.emit('cursor_changed')
-            self.emit('mode_changed')
+            self.emit('cursor-changed')
+            self.emit('mode-changed')
 
     # changes the viewer's mode to CHAR_MODE
     def setCharMode(self) -> None:
@@ -541,8 +541,8 @@ class FileDiffViewerBase(Gtk.Grid):
             self._im_focus_in()
             self.im_context.reset()
             self.mode = EditMode.CHAR
-            self.emit('cursor_changed')
-            self.emit('mode_changed')
+            self.emit('cursor-changed')
+            self.emit('mode-changed')
 
     # sets the syntax highlighting rules
     def setSyntax(self, s):
@@ -551,7 +551,7 @@ class FileDiffViewerBase(Gtk.Grid):
             # invalidate the syntax caches
             for pane in self.panes:
                 pane.syntax_cache = []
-            self.emit('syntax_changed', s)
+            self.emit('syntax-changed', s)
             # force all panes to redraw
             for darea in self.dareas:
                 darea.queue_draw()
@@ -733,7 +733,7 @@ class FileDiffViewerBase(Gtk.Grid):
             # create an Undo object for the action
             self.addUndo(FileDiffViewerBase.SetFormatUndo(f, fmt, pane.format))
         pane.format = fmt
-        self.emit('format_changed', f, fmt)
+        self.emit('format-changed', f, fmt)
 
     # Undo for the creation of Line objects
     class InstanceLineUndo:
@@ -806,7 +806,7 @@ class FileDiffViewerBase(Gtk.Grid):
         elif not is_modified and line.is_modified:
             pane.num_edits -= 1
         if pane.num_edits != old_num_edits:
-            self.emit('num_edits_changed', f)
+            self.emit('num-edits-changed', f)
         line.is_modified = is_modified
         line.modified_text = text
         line.compare_string = None
@@ -1061,7 +1061,7 @@ class FileDiffViewerBase(Gtk.Grid):
             if line is not None and line.is_modified:
                 pane.num_edits += 1
         if pane.num_edits != old_num_edits:
-            self.emit('num_edits_changed', f)
+            self.emit('num-edits-changed', f)
         del pane.syntax_cache[:]
         pane.max_line_number = new_max_num
         self.dareas[f].queue_draw()
@@ -1541,8 +1541,8 @@ class FileDiffViewerBase(Gtk.Grid):
             self.setCurrentChar(self.current_line, self.current_char, True)
         else:
             self.setCurrentLine(self.current_pane, self.current_line, self.selection_line)
-        self.emit('cursor_changed')
-        self.emit('mode_changed')
+        self.emit('cursor-changed')
+        self.emit('mode-changed')
         # queue a redraw to show the updated selection
         self.dareas[old_f].queue_draw()
 
@@ -1585,7 +1585,7 @@ class FileDiffViewerBase(Gtk.Grid):
         self.current_line = i
         self.selection_line = selection if selection is not None else i
 
-        self.emit('cursor_changed')
+        self.emit('cursor-changed')
 
         # invalidate old selection area
         self._queue_draw_lines(old_f, line0, line1)
@@ -1697,7 +1697,7 @@ class FileDiffViewerBase(Gtk.Grid):
             self._set_clipboard_text(Gdk.SELECTION_PRIMARY, self.getSelectedText())
 
         self._cursor_position_changed(True)
-        self.emit('cursor_changed')
+        self.emit('cursor-changed')
 
         # invalidate old selection area
         self._queue_draw_lines(f, line0, line1)
@@ -1809,7 +1809,7 @@ class FileDiffViewerBase(Gtk.Grid):
                     self.mode = EditMode.CHAR
                     self._im_focus_in()
                     self.button_press(f, x, y, False)
-                    self.emit('mode_changed')
+                    self.emit('mode-changed')
                 elif self.mode == EditMode.CHAR and self.current_pane == f:
                     # select word
                     text = utils.strip_eol(self.getLineText(f, i))
@@ -2528,7 +2528,7 @@ class FileDiffViewerBase(Gtk.Grid):
         self.selection_line = self.current_line
         self.align_pane = self.current_pane
         self.align_line = self.current_line
-        self.emit('mode_changed')
+        self.emit('mode-changed')
         self.dareas[self.align_pane].queue_draw()
 
     # 'first-line' keybinding action
@@ -3102,7 +3102,7 @@ class FileDiffViewerBase(Gtk.Grid):
         for pane in self.panes:
             del pane.diff_cache[:]
         # tab width may have changed
-        self.emit('cursor_changed')
+        self.emit('cursor-changed')
         for darea in self.dareas:
             darea.queue_draw()
         self.diffmap_cache = None
@@ -3298,7 +3298,7 @@ class FileDiffViewerBase(Gtk.Grid):
         # queue redraw
         self.diffmap_cache = None
         self.diffmap.queue_draw()
-        self.emit('swapped_panes', f_dst, f_src)
+        self.emit('swapped-panes', f_dst, f_src)
 
     # swap the contents of two panes
     def swap_panes(self, f_dst: int, f_src: int) -> None:

--- a/src/diffuse/widgets.py
+++ b/src/diffuse/widgets.py
@@ -215,7 +215,7 @@ class FileDiffViewerBase(Gtk.Grid):
         self.undoblock = None
 
         # cached data
-        self.syntax = None
+        self.syntax = ''
         self.diffmap_cache = None
 
         # editing mode
@@ -545,13 +545,13 @@ class FileDiffViewerBase(Gtk.Grid):
             self.emit('mode-changed')
 
     # sets the syntax highlighting rules
-    def setSyntax(self, s):
-        if self.syntax is not s:
-            self.syntax = s
+    def setSyntax(self, new_syntax: str) -> None:
+        if self.syntax is not new_syntax:
+            self.syntax = new_syntax
             # invalidate the syntax caches
             for pane in self.panes:
                 pane.syntax_cache = []
-            self.emit('syntax-changed', s)
+            self.emit('syntax-changed', new_syntax)
             # force all panes to redraw
             for darea in self.dareas:
                 darea.queue_draw()

--- a/src/diffuse/widgets.py
+++ b/src/diffuse/widgets.py
@@ -231,53 +231,53 @@ class FileDiffViewerBase(Gtk.Grid):
 
         # keybindings
         self._line_mode_actions: Dict[str, Callable] = {
-            'enter_align_mode': self._line_mode_enter_align_mode,
-            'enter_character_mode': self.setCharMode,
-            'first_line': self._first_line,
-            'extend_first_line': self._extend_first_line,
-            'last_line': self._last_line,
-            'extend_last_line': self._extend_last_line,
+            'enter-align-mode': self._line_mode_enter_align_mode,
+            'enter-character-mode': self.setCharMode,
+            'first-line': self._first_line,
+            'extend-first-line': self._extend_first_line,
+            'last-line': self._last_line,
+            'extend-last-line': self._extend_last_line,
             'up': self._line_mode_up,
-            'extend_up': self._line_mode_extend_up,
+            'extend-up': self._line_mode_extend_up,
             'down': self._line_mode_down,
-            'extend_down': self._line_mode_extend_down,
+            'extend-down': self._line_mode_extend_down,
             'left': self._line_mode_left,
-            'extend_left': self._line_mode_extend_left,
+            'extend-left': self._line_mode_extend_left,
             'right': self._line_mode_right,
-            'extend_right': self._line_mode_extend_right,
-            'page_up': self._line_mode_page_up,
-            'extend_page_up': self._line_mode_extend_page_up,
-            'page_down': self._line_mode_page_down,
-            'extend_page_down': self._line_mode_extend_page_down,
-            'delete_text': self._delete_text,
-            'clear_edits': self.clear_edits,
+            'extend-right': self._line_mode_extend_right,
+            'page-up': self._line_mode_page_up,
+            'extend-page-up': self._line_mode_extend_page_up,
+            'page-down': self._line_mode_page_down,
+            'extend-page-down': self._line_mode_extend_page_down,
+            'delete-text': self._delete_text,
+            'clear-edits': self.clear_edits,
             'isolate': self.isolate,
-            'first_difference': self.first_difference,
-            'previous_difference': self.previous_difference,
-            'next_difference': self.next_difference,
-            'last_difference': self.last_difference,
-            'copy_selection_right': self.copy_selection_right,
-            'copy_selection_left': self.copy_selection_left,
-            'copy_left_into_selection': self.copy_left_into_selection,
-            'copy_right_into_selection': self.copy_right_into_selection,
-            'merge_from_left_then_right': self.merge_from_left_then_right,
-            'merge_from_right_then_left': self.merge_from_right_then_left
+            'first-difference': self.first_difference,
+            'previous-difference': self.previous_difference,
+            'next-difference': self.next_difference,
+            'last-difference': self.last_difference,
+            'copy-selection-right': self.copy_selection_right,
+            'copy-selection-left': self.copy_selection_left,
+            'copy-left-into-selection': self.copy_left_into_selection,
+            'copy-right-into-selection': self.copy_right_into_selection,
+            'merge-from-left-then-right': self.merge_from_left_then_right,
+            'merge-from-right-then-left': self.merge_from_right_then_left
         }
         self._align_mode_actions: Dict[str, Callable] = {
-            'enter_line_mode': self._align_mode_enter_line_mode,
-            'enter_character_mode': self.setCharMode,
-            'first_line': self._first_line,
-            'last_line': self._last_line,
+            'enter-line-mode': self._align_mode_enter_line_mode,
+            'enter-character-mode': self.setCharMode,
+            'first-line': self._first_line,
+            'last-line': self._last_line,
             'up': self._line_mode_up,
             'down': self._line_mode_down,
             'left': self._line_mode_left,
             'right': self._line_mode_right,
-            'page_up': self._line_mode_page_up,
-            'page_down': self._line_mode_page_down,
+            'page-up': self._line_mode_page_up,
+            'page-down': self._line_mode_page_down,
             'align': self._align_text
         }
         self._character_mode_actions: Dict[str, Callable] = {
-            'enter_line_mode': self.setLineMode
+            'enter-line-mode': self.setLineMode
         }
         self._button_actions: Dict[str, Callable] = {
             'undo': self.undo,
@@ -285,35 +285,35 @@ class FileDiffViewerBase(Gtk.Grid):
             'cut': self.cut,
             'copy': self.copy,
             'paste': self.paste,
-            'select_all': self.select_all,
-            'clear_edits': self.clear_edits,
-            'dismiss_all_edits': self.dismiss_all_edits,
-            'realign_all': self.realign_all,
+            'select-all': self.select_all,
+            'clear-edits': self.clear_edits,
+            'dismiss-all-edits': self.dismiss_all_edits,
+            'realign-all': self.realign_all,
             'isolate': self.isolate,
-            'first_difference': self.first_difference,
-            'previous_difference': self.previous_difference,
-            'next_difference': self.next_difference,
-            'last_difference': self.last_difference,
-            'shift_pane_right': self.shift_pane_right,
-            'shift_pane_left': self.shift_pane_left,
-            'convert_to_upper_case': self.convert_to_upper_case,
-            'convert_to_lower_case': self.convert_to_lower_case,
-            'sort_lines_in_ascending_order': self.sort_lines_in_ascending_order,
-            'sort_lines_in_descending_order': self.sort_lines_in_descending_order,
-            'remove_trailing_white_space': self.remove_trailing_white_space,
-            'convert_tabs_to_spaces': self.convert_tabs_to_spaces,
-            'convert_leading_spaces_to_tabs': self.convert_leading_spaces_to_tabs,
-            'increase_indenting': self.increase_indenting,
-            'decrease_indenting': self.decrease_indenting,
-            'convert_to_dos': self.convert_to_dos,
-            'convert_to_mac': self.convert_to_mac,
-            'convert_to_unix': self.convert_to_unix,
-            'copy_selection_right': self.copy_selection_right,
-            'copy_selection_left': self.copy_selection_left,
-            'copy_left_into_selection': self.copy_left_into_selection,
-            'copy_right_into_selection': self.copy_right_into_selection,
-            'merge_from_left_then_right': self.merge_from_left_then_right,
-            'merge_from_right_then_left': self.merge_from_right_then_left
+            'first-difference': self.first_difference,
+            'previous-difference': self.previous_difference,
+            'next-difference': self.next_difference,
+            'last-difference': self.last_difference,
+            'shift-pane-right': self.shift_pane_right,
+            'shift-pane-left': self.shift_pane_left,
+            'convert-to-upper-case': self.convert_to_upper_case,
+            'convert-to-lower-case': self.convert_to_lower_case,
+            'sort-lines-in-ascending-order': self.sort_lines_in_ascending_order,
+            'sort-lines-in-descending-order': self.sort_lines_in_descending_order,
+            'remove-trailing-white-space': self.remove_trailing_white_space,
+            'convert-tabs-to-spaces': self.convert_tabs_to_spaces,
+            'convert-leading-spaces-to-tabs': self.convert_leading_spaces_to_tabs,
+            'increase-indenting': self.increase_indenting,
+            'decrease-indenting': self.decrease_indenting,
+            'convert-to-dos': self.convert_to_dos,
+            'convert-to-mac': self.convert_to_mac,
+            'convert-to-unix': self.convert_to_unix,
+            'copy-selection-right': self.copy_selection_right,
+            'copy-selection-left': self.copy_selection_left,
+            'copy-left-into-selection': self.copy_left_into_selection,
+            'copy-right-into-selection': self.copy_right_into_selection,
+            'merge-from-left-then-right': self.merge_from_left_then_right,
+            'merge-from-right-then-left': self.merge_from_right_then_left
         }
 
         # create panes
@@ -1862,8 +1862,8 @@ class FileDiffViewerBase(Gtk.Grid):
                 [_('Copy'), self.button_cb, 'copy', Gtk.STOCK_COPY, can_select],
                 [_('Paste'), self.button_cb, 'paste', Gtk.STOCK_PASTE, can_select],
                 [],
-                [_('Select All'), self.button_cb, 'select_all', None, can_select],
-                [_('Clear Edits'), self.button_cb, 'clear_edits', Gtk.STOCK_CLEAR, can_isolate],  # noqa: E501
+                [_('Select All'), self.button_cb, 'select-all', None, can_select],
+                [_('Clear Edits'), self.button_cb, 'clear-edits', Gtk.STOCK_CLEAR, can_isolate],  # noqa: E501
                 [],
                 [_('Swap with Selected Pane'), self.swap_panes_cb, f, None, can_swap]
             ])
@@ -2518,7 +2518,7 @@ class FileDiffViewerBase(Gtk.Grid):
     def getMaxCharPosition(self, i):
         return utils.len_minus_line_ending(self.getLineText(self.current_pane, i))
 
-    # 'enter_align_mode' keybinding action
+    # 'enter-align-mode' keybinding action
     def _line_mode_enter_align_mode(self):
         if self.mode == EditMode.CHAR:
             self._im_focus_out()
@@ -2531,20 +2531,20 @@ class FileDiffViewerBase(Gtk.Grid):
         self.emit('mode_changed')
         self.dareas[self.align_pane].queue_draw()
 
-    # 'first_line' keybinding action
+    # 'first-line' keybinding action
     def _first_line(self):
         self.setCurrentLine(self.current_pane, 0)
 
-    # 'extend_first_line' keybinding action
+    # 'extend-first-line' keybinding action
     def _extend_first_line(self):
         self.setCurrentLine(self.current_pane, 0, self.selection_line)
 
-    # 'last_line' keybinding action
+    # 'last-line' keybinding action
     def _last_line(self):
         f = self.current_pane
         self.setCurrentLine(f, len(self.panes[f].lines))
 
-    # 'extend_last_line' keybinding action
+    # 'extend-last-line' keybinding action
     def _extend_last_line(self):
         f = self.current_pane
         self.setCurrentLine(f, len(self.panes[f].lines), self.selection_line)
@@ -2553,7 +2553,7 @@ class FileDiffViewerBase(Gtk.Grid):
     def _line_mode_up(self, selection=None):
         self.setCurrentLine(self.current_pane, self.current_line - 1, selection)
 
-    # 'extend_up' keybinding action
+    # 'extend-up' keybinding action
     def _line_mode_extend_up(self):
         self._line_mode_up(self.selection_line)
 
@@ -2561,7 +2561,7 @@ class FileDiffViewerBase(Gtk.Grid):
     def _line_mode_down(self, selection=None):
         self.setCurrentLine(self.current_pane, self.current_line + 1, selection)
 
-    # 'extend_down' keybinding action
+    # 'extend-down' keybinding action
     def _line_mode_extend_down(self):
         self._line_mode_down(self.selection_line)
 
@@ -2569,7 +2569,7 @@ class FileDiffViewerBase(Gtk.Grid):
     def _line_mode_left(self, selection=None):
         self.setCurrentLine(self.current_pane - 1, self.current_line, selection)
 
-    # 'extend_left' keybinding action
+    # 'extend-left' keybinding action
     def _line_mode_extend_left(self):
         self._line_mode_left(self.selection_line)
 
@@ -2577,33 +2577,33 @@ class FileDiffViewerBase(Gtk.Grid):
     def _line_mode_right(self, selection=None):
         self.setCurrentLine(self.current_pane + 1, self.current_line, selection)
 
-    # 'extend_right' keybinding action
+    # 'extend-right' keybinding action
     def _line_mode_extend_right(self):
         self._line_mode_right(self.selection_line)
 
-    # 'page_up' keybinding action
+    # 'page-up' keybinding action
     def _line_mode_page_up(self, selection=None):
         delta = int(self.vadj.get_page_size() // self.font_height)
         self.setCurrentLine(self.current_pane, self.current_line - delta, selection)
 
-    # 'extend_page_up' keybinding action
+    # 'extend-page-up' keybinding action
     def _line_mode_extend_page_up(self) -> None:
         self._line_mode_page_up(self.selection_line)
 
-    # 'page_down' keybinding action
+    # 'page-down' keybinding action
     def _line_mode_page_down(self, selection=None):
         delta = int(self.vadj.get_page_size() // self.font_height)
         self.setCurrentLine(self.current_pane, self.current_line + delta, selection)
 
-    # 'extend_page_down' keybinding action
+    # 'extend-page-down' keybinding action
     def _line_mode_extend_page_down(self) -> None:
         self._line_mode_page_down(self.selection_line)
 
-    # 'delete_text' keybinding action
+    # 'delete-text' keybinding action
     def _delete_text(self) -> None:
         self.replaceText('')
 
-    # 'enter_line_mode' keybinding action
+    # 'enter-line-mode' keybinding action
     def _align_mode_enter_line_mode(self) -> None:
         self.selection_line = self.current_line
         self.setLineMode()
@@ -2991,7 +2991,7 @@ class FileDiffViewerBase(Gtk.Grid):
             self.receive_clipboard_text_cb,
             None)
 
-    # 'clear_edits' action
+    # 'clear-edits' action
     def clear_edits(self) -> None:
         self.setLineMode()
         self.recordEditMode()
@@ -3010,7 +3010,7 @@ class FileDiffViewerBase(Gtk.Grid):
                     self.instanceLine(f, i, True)
         self.recordEditMode()
 
-    # 'dismiss_all_edits' action
+    # 'dismiss-all-edits' action
     def dismiss_all_edits(self) -> None:
         if self.mode in (EditMode.LINE, EditMode.CHAR):
             self.bakeEdits(self.current_pane)
@@ -3108,7 +3108,7 @@ class FileDiffViewerBase(Gtk.Grid):
         self.diffmap_cache = None
         self.diffmap.queue_draw()
 
-    # 'realign_all' action
+    # 'realign-all' action
     def realign_all(self) -> None:
         self.setLineMode()
         f = self.current_pane
@@ -3243,24 +3243,24 @@ class FileDiffViewerBase(Gtk.Grid):
             self.centre_view_about_y((start + i) * self.font_height / 2)
             self.setCurrentLine(f, start, i)
 
-    # 'first_difference' action
+    # 'first-difference' action
     def first_difference(self) -> None:
         self.setLineMode()
         self.go_to_difference(0, 1)
 
-    # 'previous_difference' action
+    # 'previous-difference' action
     def previous_difference(self) -> None:
         self.setLineMode()
         i = min(self.current_line, self.selection_line) - 1
         self.go_to_difference(i, -1)
 
-    # 'next_difference' action
+    # 'next-difference' action
     def next_difference(self) -> None:
         self.setLineMode()
         i = max(self.current_line, self.selection_line) + 1
         self.go_to_difference(i, 1)
 
-    # 'last_difference' action
+    # 'last-difference' action
     def last_difference(self) -> None:
         self.setLineMode()
         i = len(self.panes[self.current_pane].lines)
@@ -3315,17 +3315,17 @@ class FileDiffViewerBase(Gtk.Grid):
         self.swap_panes(data, self.current_pane)
         self.closeUndoBlock()
 
-    # 'shift_pane_left' action
+    # 'shift-pane-left' action
     def shift_pane_left(self) -> None:
         f = self.current_pane
         self.swap_panes(f - 1, f)
 
-    # 'shift_pane_right' action
+    # 'shift-pane-right' action
     def shift_pane_right(self) -> None:
         f = self.current_pane
         self.swap_panes(f + 1, f)
 
-    # 'convert_to_upper_case' action
+    # 'convert-to-upper-case' action
     def _convert_case(self, to_upper: bool) -> None:
         # find range of characters to operate upon
         if self.mode == EditMode.CHAR:
@@ -3366,11 +3366,11 @@ class FileDiffViewerBase(Gtk.Grid):
                 if s != text:
                     self.updateText(f, i, s)
 
-    # 'convert_to_upper_case' action
+    # 'convert-to-upper-case' action
     def convert_to_upper_case(self) -> None:
         self._convert_case(True)
 
-    # 'convert_to_lower_case' action
+    # 'convert-to-lower-case' action
     def convert_to_lower_case(self) -> None:
         self._convert_case(False)
 
@@ -3402,15 +3402,15 @@ class FileDiffViewerBase(Gtk.Grid):
             self.setCurrentChar(self.current_line, 0, self.selection_line, 0)
         self.recordEditMode()
 
-    # 'sort_lines_in_ascending_order' action
+    # 'sort-lines-in-ascending-order' action
     def sort_lines_in_ascending_order(self) -> None:
         self._sort_lines(False)
 
-    # 'sort_lines_in_descending_order' action
+    # 'sort-lines-in-descending-order' action
     def sort_lines_in_descending_order(self) -> None:
         self._sort_lines(True)
 
-    # 'remove_trailing_white_space' action
+    # 'remove-trailing-white-space' action
     def remove_trailing_white_space(self) -> None:
         if self.mode != EditMode.CHAR:
             self.setLineMode()
@@ -3436,7 +3436,7 @@ class FileDiffViewerBase(Gtk.Grid):
             self.setCurrentChar(self.current_line, 0, self.selection_line, 0)
         self.recordEditMode()
 
-    # 'convert_tabs_to_spaces' action
+    # 'convert-tabs-to-spaces' action
     def convert_tabs_to_spaces(self) -> None:
         # find range of characters to operate upon
         if self.mode == EditMode.CHAR:
@@ -3489,7 +3489,7 @@ class FileDiffViewerBase(Gtk.Grid):
             self.setCurrentChar(end, j1, start, j0)
         self.recordEditMode()
 
-    # 'convert_leading_spaces_to_tabs' action
+    # 'convert-leading-spaces-to-tabs' action
     def convert_leading_spaces_to_tabs(self) -> None:
         if self.mode != EditMode.CHAR:
             self.setLineMode()
@@ -3552,11 +3552,11 @@ class FileDiffViewerBase(Gtk.Grid):
             self.setCurrentChar(self.current_line, 0, self.selection_line, 0)
         self.recordEditMode()
 
-    # 'increase_indenting' action
+    # 'increase-indenting' action
     def increase_indenting(self) -> None:
         self._adjust_indenting(1)
 
-    # 'decrease_indenting' action
+    # 'decrease-indenting' action
     def decrease_indenting(self) -> None:
         self._adjust_indenting(-1)
 
@@ -3572,15 +3572,15 @@ class FileDiffViewerBase(Gtk.Grid):
                 self.updateText(f, i, s)
         self.setFormat(f, fmt)
 
-    # 'convert_to_dos' action
+    # 'convert-to-dos' action
     def convert_to_dos(self) -> None:
         self.convert_format(LineEnding.DOS_FORMAT)
 
-    # 'convert_to_mac' action
+    # 'convert-to-mac' action
     def convert_to_mac(self) -> None:
         self.convert_format(LineEnding.MAC_FORMAT)
 
-    # 'convert_to_unix' action
+    # 'convert-to-unix' action
     def convert_to_unix(self) -> None:
         self.convert_format(LineEnding.UNIX_FORMAT)
 
@@ -3614,25 +3614,25 @@ class FileDiffViewerBase(Gtk.Grid):
         self.merge_lines(data, self.current_pane)
         self.closeUndoBlock()
 
-    # 'copy_selection_right' action
+    # 'copy-selection-right' action
     def copy_selection_right(self) -> None:
         f = self.current_pane + 1
         if 0 < f < len(self.panes):
             self.merge_lines(f, f - 1)
 
-    # 'copy_selection_left' action
+    # 'copy-selection-left' action
     def copy_selection_left(self) -> None:
         f = self.current_pane - 1
         if f >= 0 and f + 1 < len(self.panes):
             self.merge_lines(f, f + 1)
 
-    # 'copy_left_into_selection' action
+    # 'copy-left-into-selection' action
     def copy_left_into_selection(self) -> None:
         f = self.current_pane
         if 0 < f < len(self.panes):
             self.merge_lines(f, f - 1)
 
-    # 'copy_right_into_selection' action
+    # 'copy-right-into-selection' action
     def copy_right_into_selection(self) -> None:
         f = self.current_pane
         if f >= 0 and f + 1 < len(self.panes):
@@ -3720,11 +3720,11 @@ class FileDiffViewerBase(Gtk.Grid):
             self.setCurrentLine(f, end, start)
         self.recordEditMode()
 
-    # 'merge_from_left_then_right' keybinding action
+    # 'merge-from-left-then-right' keybinding action
     def merge_from_left_then_right(self):
         self._mergeBoth(False)
 
-    # 'merge_from_right_then_left' keybinding action
+    # 'merge-from-right-then-left' keybinding action
     def merge_from_right_then_left(self):
         self._mergeBoth(True)
 

--- a/src/diffuse/window.py
+++ b/src/diffuse/window.py
@@ -146,7 +146,7 @@ class PaneHeader(Gtk.Box):
         self.show_all()
 
     # callback for buttons
-    def button_cb(self, widget, s):
+    def button_cb(self, widget: Gtk.Widget, s: str) -> None:
         self.emit(s)
 
     # creates an appropriate title for the pane header
@@ -779,22 +779,22 @@ class DiffuseWindow(Gtk.ApplicationWindow):
         menu_specs = []
         menu_specs.append([_('_File'), [
             [
-                [_('_Open File...'), self.open_file_cb, None, 'open_file'],
-                [_('Open File In New _Tab...'), self.open_file_in_new_tab_cb, None, 'open_file_in_new_tab'],  # noqa: E501
-                [_('Open _Modified Files...'), self.open_modified_files_cb, None, 'open_modified_files'],  # noqa: E501
-                [_('Open Commi_t...'), self.open_commit_cb, None, 'open_commit'],
-                [_('_Reload File'), self.reload_file_cb, None, 'reload_file'],
+                [_('_Open File...'), self.open_file_cb, None, 'open-file'],
+                [_('Open File In New _Tab...'), self.open_file_in_new_tab_cb, None, 'open-file-in-new-tab'],  # noqa: E501
+                [_('Open _Modified Files...'), self.open_modified_files_cb, None, 'open-modified-files'],  # noqa: E501
+                [_('Open Commi_t...'), self.open_commit_cb, None, 'open-commit'],
+                [_('_Reload File'), self.reload_file_cb, None, 'reload-file'],
             ], [
-                [_('_Save File'), self.save_file_cb, None, 'save_file'],
-                [_('Save File _As...'), self.save_file_as_cb, None, 'save_file_as'],
-                [_('Save A_ll'), self.save_all_cb, None, 'save_all'],
+                [_('_Save File'), self.save_file_cb, None, 'save-file'],
+                [_('Save File _As...'), self.save_file_as_cb, None, 'save-file-as'],
+                [_('Save A_ll'), self.save_all_cb, None, 'save-all'],
             ], [
-                [_('New _2-Way File Merge'), self.new_2_way_file_merge_cb, None, 'new_2_way_file_merge'],  # noqa: E501
-                [_('New _3-Way File Merge'), self.new_3_way_file_merge_cb, None, 'new_3_way_file_merge'],  # noqa: E501
-                [_('New _N-Way File Merge...'), self.new_n_way_file_merge_cb, None, 'new_n_way_file_merge'],  # noqa: E501
+                [_('New _2-Way File Merge'), self.new_2_way_file_merge_cb, None, 'new-2-way-file-merge'],  # noqa: E501
+                [_('New _3-Way File Merge'), self.new_3_way_file_merge_cb, None, 'new-3-way-file-merge'],  # noqa: E501
+                [_('New _N-Way File Merge...'), self.new_n_way_file_merge_cb, None, 'new-n-way-file-merge'],  # noqa: E501
             ], [
-                [_('_Close Tab'), self.close_tab_cb, None, 'close_tab'],
-                [_('_Undo Close Tab'), self.undo_close_tab_cb, None, 'undo_close_tab'],
+                [_('_Close Tab'), self.close_tab_cb, None, 'close-tab'],
+                [_('_Undo Close Tab'), self.undo_close_tab_cb, None, 'undo-close-tab'],
                 [_('_Quit'), self.quit_cb, None, 'quit']
             ]
         ]])
@@ -808,24 +808,24 @@ class DiffuseWindow(Gtk.ApplicationWindow):
                 [_('_Copy'), self.menuitem_cb, 'copy', 'copy'],
                 [_('_Paste'), self.menuitem_cb, 'paste', 'paste'],
             ], [
-                [_('Select _All'), self.menuitem_cb, 'select_all', 'select_all'],
-                [_('C_lear Edits'), self.menuitem_cb, 'clear_edits', 'clear_edits'],
-                [_('_Dismiss All Edits'), self.menuitem_cb, 'dismiss_all_edits', 'dismiss_all_edits'],  # noqa: E501
+                [_('Select _All'), self.menuitem_cb, 'select-all', 'select-all'],
+                [_('C_lear Edits'), self.menuitem_cb, 'clear-edits', 'clear-edits'],
+                [_('_Dismiss All Edits'), self.menuitem_cb, 'dismiss-all-edits', 'dismiss-all-edits'],  # noqa: E501
             ], [
                 [_('_Find...'), self.find_cb, None, 'find'],
-                [_('Find _Next'), self.find_next_cb, None, 'find_next'],
-                [_('Find Pre_vious'), self.find_previous_cb, None, 'find_previous'],
-                [_('_Go To Line...'), self.go_to_line_cb, None, 'go_to_line'],
+                [_('Find _Next'), self.find_next_cb, None, 'find-next'],
+                [_('Find Pre_vious'), self.find_previous_cb, None, 'find-previous'],
+                [_('_Go To Line...'), self.go_to_line_cb, None, 'go-to-line'],
             ], [
                 [_('Pr_eferences...'), self.preferences_cb, None, 'preferences']
             ]
         ]])
 
-        syntax_menu = [[[_('None'), None, '', 'syntax_highlighting']]]
+        syntax_menu = [[[_('None'), None, '', 'syntax-highlighting']]]
         names = theResources.getSyntaxNames()
         variant = GLib.Variant.new_string('')
         self.syntax_action = Gio.SimpleAction.new_stateful(
-            'syntax_highlighting', variant.get_type(), variant
+            'syntax-highlighting', variant.get_type(), variant
         )
         self.syntax_action.connect('change-state', self.syntax_cb)
         self.add_action(self.syntax_action)
@@ -838,7 +838,7 @@ class DiffuseWindow(Gtk.ApplicationWindow):
                         name,
                         None,
                         name,
-                        'syntax_highlighting',
+                        'syntax-highlighting',
                     ]
                 )
             syntax_menu.append(syntax_section)
@@ -847,60 +847,60 @@ class DiffuseWindow(Gtk.ApplicationWindow):
             [
                 [_('_Syntax Highlighting'), None, None, None, syntax_menu]
             ], [
-                [_('Re_align All'), self.menuitem_cb, 'realign_all', 'realign_all'],
+                [_('Re_align All'), self.menuitem_cb, 'realign-all', 'realign-all'],
                 [_('_Isolate'), self.menuitem_cb, 'isolate', 'isolate'],
             ], [
-                [_('_First Difference'), self.menuitem_cb, 'first_difference', 'first_difference'],
-                [_('_Previous Difference'), self.menuitem_cb, 'previous_difference', 'previous_difference'],  # noqa: E501
-                [_('_Next Difference'), self.menuitem_cb, 'next_difference', 'next_difference'],
-                [_('_Last Difference'), self.menuitem_cb, 'last_difference', 'last_difference'],
+                [_('_First Difference'), self.menuitem_cb, 'first-difference', 'first-difference'],
+                [_('_Previous Difference'), self.menuitem_cb, 'previous-difference', 'previous-difference'],  # noqa: E501
+                [_('_Next Difference'), self.menuitem_cb, 'next-difference', 'next-difference'],
+                [_('_Last Difference'), self.menuitem_cb, 'last-difference', 'last-difference'],
             ], [
-                [_('Fir_st Tab'), self.first_tab_cb, None, 'first_tab'],
-                [_('Pre_vious Tab'), self.previous_tab_cb, None, 'previous_tab'],
-                [_('Next _Tab'), self.next_tab_cb, None, 'next_tab'],
-                [_('Las_t Tab'), self.last_tab_cb, None, 'last_tab'],
+                [_('Fir_st Tab'), self.first_tab_cb, None, 'first-tab'],
+                [_('Pre_vious Tab'), self.previous_tab_cb, None, 'previous-tab'],
+                [_('Next _Tab'), self.next_tab_cb, None, 'next-tab'],
+                [_('Las_t Tab'), self.last_tab_cb, None, 'last-tab'],
             ], [
-                [_('Shift Pane _Right'), self.menuitem_cb, 'shift_pane_right', 'shift_pane_right'],
-                [_('Shift Pane _Left'), self.menuitem_cb, 'shift_pane_left', 'shift_pane_left']
+                [_('Shift Pane _Right'), self.menuitem_cb, 'shift-pane-right', 'shift-pane-right'],
+                [_('Shift Pane _Left'), self.menuitem_cb, 'shift-pane-left', 'shift-pane-left']
             ]
         ]])
 
         menu_specs.append([_('F_ormat'), [
             [
-                [_('Convert To _Upper Case'), self.menuitem_cb, 'convert_to_upper_case', 'convert_to_upper_case'],  # noqa: E501
-                [_('Convert To _Lower Case'), self.menuitem_cb, 'convert_to_lower_case', 'convert_to_lower_case'],  # noqa: E501
+                [_('Convert To _Upper Case'), self.menuitem_cb, 'convert-to-upper-case', 'convert-to-upper-case'],  # noqa: E501
+                [_('Convert To _Lower Case'), self.menuitem_cb, 'convert-to-lower-case', 'convert-to-lower-case'],  # noqa: E501
             ], [
-                [_('Sort Lines In _Ascending Order'), self.menuitem_cb, 'sort_lines_in_ascending_order', 'sort_lines_in_ascending_order'],  # noqa: E501
-                [_('Sort Lines In D_escending Order'), self.menuitem_cb, 'sort_lines_in_descending_order', 'sort_lines_in_descending_order'],  # noqa: E501
+                [_('Sort Lines In _Ascending Order'), self.menuitem_cb, 'sort-lines-in-ascending-order', 'sort-lines-in-ascending-order'],  # noqa: E501
+                [_('Sort Lines In D_escending Order'), self.menuitem_cb, 'sort-lines-in-descending-order', 'sort-lines-in-descending-order'],  # noqa: E501
             ], [
-                [_('Remove Trailing _White Space'), self.menuitem_cb, 'remove_trailing_white_space', 'remove_trailing_white_space'],  # noqa: E501
-                [_('Convert Tabs To _Spaces'), self.menuitem_cb, 'convert_tabs_to_spaces', 'convert_tabs_to_spaces'],  # noqa: E501
-                [_('Convert Leading Spaces To _Tabs'), self.menuitem_cb, 'convert_leading_spaces_to_tabs', 'convert_leading_spaces_to_tabs'],  # noqa: E501
+                [_('Remove Trailing _White Space'), self.menuitem_cb, 'remove-trailing-white-space', 'remove-trailing-white-space'],  # noqa: E501
+                [_('Convert Tabs To _Spaces'), self.menuitem_cb, 'convert-tabs-to-spaces', 'convert-tabs-to-spaces'],  # noqa: E501
+                [_('Convert Leading Spaces To _Tabs'), self.menuitem_cb, 'convert-leading-spaces-to-tabs', 'convert-leading-spaces-to-tabs'],  # noqa: E501
             ], [
-                [_('_Increase Indenting'), self.menuitem_cb, 'increase_indenting', 'increase_indenting'],  # noqa: E501
-                [_('De_crease Indenting'), self.menuitem_cb, 'decrease_indenting', 'decrease_indenting'],  # noqa: E501
+                [_('_Increase Indenting'), self.menuitem_cb, 'increase-indenting', 'increase-indenting'],  # noqa: E501
+                [_('De_crease Indenting'), self.menuitem_cb, 'decrease-indenting', 'decrease-indenting'],  # noqa: E501
             ], [
-                [_('Convert To _DOS Format'), self.menuitem_cb, 'convert_to_dos', 'convert_to_dos'],
-                [_('Convert To _Mac Format'), self.menuitem_cb, 'convert_to_mac', 'convert_to_mac'],
-                [_('Convert To Uni_x Format'), self.menuitem_cb, 'convert_to_unix', 'convert_to_unix']  # noqa: E501
+                [_('Convert To _DOS Format'), self.menuitem_cb, 'convert-to-dos', 'convert-to-dos'],
+                [_('Convert To _Mac Format'), self.menuitem_cb, 'convert-to-mac', 'convert-to-mac'],
+                [_('Convert To Uni_x Format'), self.menuitem_cb, 'convert-to-unix', 'convert-to-unix']  # noqa: E501
             ]
         ]])
 
         menu_specs.append([_('_Merge'), [
             [
-                [_('Copy Selection _Right'), self.menuitem_cb, 'copy_selection_right', 'copy_selection_right'],  # noqa: E501
-                [_('Copy Selection _Left'), self.menuitem_cb, 'copy_selection_left', 'copy_selection_left'],  # noqa: E501
+                [_('Copy Selection _Right'), self.menuitem_cb, 'copy-selection-right', 'copy-selection-right'],  # noqa: E501
+                [_('Copy Selection _Left'), self.menuitem_cb, 'copy-selection-left', 'copy-selection-left'],  # noqa: E501
             ], [
-                [_('Copy Left _Into Selection'), self.menuitem_cb, 'copy_left_into_selection', 'copy_left_into_selection'],  # noqa: E501
-                [_('Copy Right I_nto Selection'), self.menuitem_cb, 'copy_right_into_selection', 'copy_right_into_selection'],  # noqa: E501
-                [_('_Merge From Left Then Right'), self.menuitem_cb, 'merge_from_left_then_right', 'merge_from_left_then_right'],  # noqa: E501
-                [_('M_erge From Right Then Left'), self.menuitem_cb, 'merge_from_right_then_left', 'merge_from_right_then_left']  # noqa: E501
+                [_('Copy Left _Into Selection'), self.menuitem_cb, 'copy-left-into-selection', 'copy-left-into-selection'],  # noqa: E501
+                [_('Copy Right I_nto Selection'), self.menuitem_cb, 'copy-right-into-selection', 'copy-right-into-selection'],  # noqa: E501
+                [_('_Merge From Left Then Right'), self.menuitem_cb, 'merge-from-left-then-right', 'merge-from-left-then-right'],  # noqa: E501
+                [_('M_erge From Right Then Left'), self.menuitem_cb, 'merge-from-right-then-left', 'merge-from-right-then-left']  # noqa: E501
             ]
         ]])
 
         menu_specs.append([_('_Help'), [
             [
-                [_('_Help Contents...'), self.help_contents_cb, None, 'help_contents'],
+                [_('_Help Contents...'), self.help_contents_cb, None, 'help-contents'],
             ], [
                 [_('_About %s...') % (constants.APP_NAME, ), self.about_cb, None, 'about']
             ]
@@ -920,25 +920,25 @@ class DiffuseWindow(Gtk.ApplicationWindow):
             [DIFFUSE_STOCK_NEW_2WAY_MERGE, self.new_2_way_file_merge_cb, None, _('New 2-Way File Merge')],  # noqa: E501
             [DIFFUSE_STOCK_NEW_3WAY_MERGE, self.new_3_way_file_merge_cb, None, _('New 3-Way File Merge')],  # noqa: E501
             [],
-            [Gtk.STOCK_EXECUTE, self.button_cb, 'realign_all', _('Realign All')],
-            [Gtk.STOCK_GOTO_TOP, self.button_cb, 'first_difference', _('First Difference')],
-            [Gtk.STOCK_GO_UP, self.button_cb, 'previous_difference', _('Previous Difference')],
-            [Gtk.STOCK_GO_DOWN, self.button_cb, 'next_difference', _('Next Difference')],
-            [Gtk.STOCK_GOTO_BOTTOM, self.button_cb, 'last_difference', _('Last Difference')],
+            [Gtk.STOCK_EXECUTE, self.button_cb, 'realign-all', _('Realign All')],
+            [Gtk.STOCK_GOTO_TOP, self.button_cb, 'first-difference', _('First Difference')],
+            [Gtk.STOCK_GO_UP, self.button_cb, 'previous-difference', _('Previous Difference')],
+            [Gtk.STOCK_GO_DOWN, self.button_cb, 'next-difference', _('Next Difference')],
+            [Gtk.STOCK_GOTO_BOTTOM, self.button_cb, 'last-difference', _('Last Difference')],
             [],
-            [Gtk.STOCK_GOTO_LAST, self.button_cb, 'copy_selection_right', _('Copy Selection Right')],  # noqa: E501
-            [Gtk.STOCK_GOTO_FIRST, self.button_cb, 'copy_selection_left', _('Copy Selection Left')],
-            [Gtk.STOCK_GO_FORWARD, self.button_cb, 'copy_left_into_selection', _('Copy Left Into Selection')],  # noqa: E501
-            [Gtk.STOCK_GO_BACK, self.button_cb, 'copy_right_into_selection', _('Copy Right Into Selection')],  # noqa: E501
-            [DIFFUSE_STOCK_LEFT_RIGHT, self.button_cb, 'merge_from_left_then_right', _('Merge From Left Then Right')],  # noqa: E501
-            [DIFFUSE_STOCK_RIGHT_LEFT, self.button_cb, 'merge_from_right_then_left', _('Merge From Right Then Left')],  # noqa: E501
+            [Gtk.STOCK_GOTO_LAST, self.button_cb, 'copy-selection-right', _('Copy Selection Right')],  # noqa: E501
+            [Gtk.STOCK_GOTO_FIRST, self.button_cb, 'copy-selection-left', _('Copy Selection Left')],
+            [Gtk.STOCK_GO_FORWARD, self.button_cb, 'copy-left-into-selection', _('Copy Left Into Selection')],  # noqa: E501
+            [Gtk.STOCK_GO_BACK, self.button_cb, 'copy-right-into-selection', _('Copy Right Into Selection')],  # noqa: E501
+            [DIFFUSE_STOCK_LEFT_RIGHT, self.button_cb, 'merge-from-left-then-right', _('Merge From Left Then Right')],  # noqa: E501
+            [DIFFUSE_STOCK_RIGHT_LEFT, self.button_cb, 'merge-from-right-then-left', _('Merge From Right Then Left')],  # noqa: E501
             [],
             [Gtk.STOCK_UNDO, self.button_cb, 'undo', _('Undo')],
             [Gtk.STOCK_REDO, self.button_cb, 'redo', _('Redo')],
             [Gtk.STOCK_CUT, self.button_cb, 'cut', _('Cut')],
             [Gtk.STOCK_COPY, self.button_cb, 'copy', _('Copy')],
             [Gtk.STOCK_PASTE, self.button_cb, 'paste', _('Paste')],
-            [Gtk.STOCK_CLEAR, self.button_cb, 'clear_edits', _('Clear Edits')]
+            [Gtk.STOCK_CLEAR, self.button_cb, 'clear-edits', _('Clear Edits')]
         ]
         _append_buttons(hbox, Gtk.IconSize.LARGE_TOOLBAR, button_specs)
         # avoid the button bar from dictating the minimum window size
@@ -966,28 +966,40 @@ class DiffuseWindow(Gtk.ApplicationWindow):
         menu = Gio.Menu.new()
         for section in sections:
             section_menu = Gio.Menu.new()
-            for label, cb, cb_data, accel, *submenu in section:
+            for label, cb, cb_data, action_name, *submenu in section:
                 if submenu:
                     (submenu,) = submenu
                     section_menu.append_submenu(label, self._create_menu(submenu))
                 else:
+                    # Convert cb_data to GLib.Variant
                     if cb_data is not None:
                         cb_data = GLib.Variant.new_string(cb_data)
-                    gtk_compliant_accel = accel.replace('_', '-')
+
+                    # Create action (if callback is not null, which shouldn't happen)
                     if cb is not None:
                         cb_data_type = cb_data and cb_data.get_type()
-                        action = Gio.SimpleAction.new(gtk_compliant_accel, cb_data_type)
+                        action = Gio.SimpleAction.new(action_name, cb_data_type)
                         action.connect('activate', cb)
                         self.add_action(action)
+
+                    # Create menu item
                     item = Gio.MenuItem.new(label)
-                    item.set_action_and_target_value('win.' + gtk_compliant_accel, cb_data)
-                    key_binding = theResources.getKeyBindings('menu', accel)
+
+                    # Attach action
+                    win_action_name = 'win.' + action_name
+                    item.set_action_and_target_value(win_action_name, cb_data)
+
+                    # Bind accelerator (in any)
+                    key_binding = theResources.getKeyBindings('menu', action_name)
                     if len(key_binding) > 0:
-                        action_name = 'win.' + gtk_compliant_accel
-                        detailed_action_name = Gio.Action.print_detailed_name(action_name, cb_data)
+                        detailed_action_name = Gio.Action.print_detailed_name(win_action_name, cb_data)  # noqa: 501
                         accels = [Gtk.accelerator_name(*key_binding[0])]
                         self.get_application().set_accels_for_action(detailed_action_name, accels)
+
+                    # Append item to menu
                     section_menu.append_item(item)
+
+            # Append section to menu
             menu.append_section(None, section_menu)
         return menu
 

--- a/src/diffuse/window.py
+++ b/src/diffuse/window.py
@@ -906,9 +906,6 @@ class DiffuseWindow(Gtk.ApplicationWindow):
             ]
         ]])
 
-        # used to disable menu events when switching tabs
-        self.menu_update_depth = 0
-
         menubar = Gio.Menu()
         for label, sections in menu_specs:
             menubar.append_submenu(label, self._create_menu(sections))
@@ -1257,9 +1254,9 @@ class DiffuseWindow(Gtk.ApplicationWindow):
         sb.push(context, s)
 
     # update the label in the status bar
-    def setSyntax(self, s):
+    def setSyntax(self, s: str) -> None:
         # update menu
-        self.syntax_action.set_state(GLib.Variant.new_string(s or ''))
+        self.syntax_action.set_state(GLib.Variant.new_string(s))
 
     # callback used when switching notebook pages
     def switch_page_cb(self, widget, ptr, page_num):
@@ -1691,11 +1688,8 @@ class DiffuseWindow(Gtk.ApplicationWindow):
             self.preferences_updated()
 
     # callback for all of the syntax highlighting menu items
-    def syntax_cb(self, widget, data):
-        # ignore events while we update the menu when switching tabs
-        # also ignore notification of the newly disabled item
-        if self.menu_update_depth == 0 and widget.get_active():
-            self.getCurrentViewer().setSyntax(data)
+    def syntax_cb(self, widget: Gtk.Widget, data: GLib.Variant) -> None:
+        self.getCurrentViewer().setSyntax(data.get_string())
 
     # callback for the first tab menu item
     def first_tab_cb(self, widget, data):

--- a/src/diffuse/window.py
+++ b/src/diffuse/window.py
@@ -166,7 +166,7 @@ class PaneHeader(Gtk.Box):
         s = ' '.join(ss)
         self.label.set_text(s)
         self.label.set_tooltip_text(s)
-        self.emit('title_changed')
+        self.emit('title-changed')
 
     # set num edits
     def setEdits(self, has_edits: bool) -> None:
@@ -373,7 +373,7 @@ class FileDiffViewer(FileDiffViewerBase):
         s = self.title
         if has_edits:
             s += ' *'
-        self.emit('title_changed', s)
+        self.emit('title-changed', s)
 
     def setEncoding(self, f, encoding):
         h = self.headers[f]
@@ -653,7 +653,7 @@ class FileDiffViewer(FileDiffViewerBase):
         else:
             s = None
         self.status = s
-        self.emit('status_changed', s)
+        self.emit('status-changed', s)
 
     # gets the status bar text
     def getStatus(self) -> Optional[str]:


### PR DESCRIPTION
Fix a couple of issues:
* Renamed all the action names to get rid of the quick fix that was replacing `_` by `-` at runtime
* Some signals weren't properly renamed from the previous GTK3 migration
* Fixed the syntax menu that wasn't working anymore