### PR TITLE
Full diff

### DIFF
--- a/src/diffuse/vcs/git.py
+++ b/src/diffuse/vcs/git.py
@@ -39,7 +39,10 @@ class Git(VcsInterface):
         for name in names:
             isabs |= os.path.isabs(name)
         # run command
-        prev = rev + '^'
+        if '..' in rev:
+            prev, rev = rev.split('..')
+        else:
+            prev = rev + '^'
         fs = FolderSet(names)
         modified = {}
         for s in utils.popenReadLines(self.root, args, prefs, 'git_bash'):

--- a/src/diffuse/vcs/hg.py
+++ b/src/diffuse/vcs/hg.py
@@ -66,6 +66,12 @@ class Hg(VcsInterface):
             args.append(utils.safeRelativePath(self.root, name, prefs, 'hg_cygwin'))
         # run command
         prev = self._getPreviousRevision(prefs, rev)
+        if rev is not None:
+            if '..' in rev:
+                prev, rev = rev.split('..')
+                args.extend(['-r',prev,'-r',rev])
+            else:
+                args.extend(['-r',rev])
         fs = FolderSet(names)
         modified = {}
         for s in utils.popenReadLines(self.root, args, prefs, 'hg_bash'):
@@ -92,7 +98,7 @@ class Hg(VcsInterface):
         return self._getCommitTemplate(
             prefs,
             names,
-            ['log', '--template', 'A\t{file_adds}\nM\t{file_mods}\nR\t{file_dels}\n', '-r', rev],
+            ['log', '--template', 'A\t{file_adds}\nM\t{file_mods}\nR\t{file_dels}\n'],
             rev)
 
     def getFolderTemplate(self, prefs, names):


### PR DESCRIPTION
Provides full diff (all files) between two commits for git and mercurial.
Usage:

    diffuse -c commit1..commit2   # displays the diff between commi1 and commit2

Provides a partial answer to issue #190 for git and mercurial only.