### PR TITLE
fix: fix compatibility with Python 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove support for the SVK CVS (@MightyCreak)
 
+### Fixed
+
+- Fix compatibility with Python 3.12: remove use of `distutils` (@MightyCreak)
+
 ## 0.8.2 - 2023-04-16
 
 ### Added

--- a/src/diffuse/resources.py
+++ b/src/diffuse/resources.py
@@ -30,7 +30,6 @@ import platform
 import re
 import shlex
 
-from distutils import util
 from gettext import gettext as _
 from typing import Dict, Final, List, Optional, Pattern, Set, Tuple
 
@@ -322,7 +321,7 @@ class Resources:
 
     def getOptionAsBool(self, option: str) -> bool:
         '''Get the option value, casted as a boolean.'''
-        return bool(util.strtobool(self.getOption(option)))
+        return bool(self.getOption(option).lower() in ['true', '1'])
 
     # string resources
     def getString(self, symbol: str) -> str:


### PR DESCRIPTION
Remove use of `distutils` which has been removed from Python 3.12 (see:
https://docs.python.org/3/whatsnew/3.12.html#summary-release-highlights)

Fixes #215