### PR TITLE
Appdata related patches

### DIFF
--- a/data/io.github.mightycreak.Diffuse.appdata.xml.in
+++ b/data/io.github.mightycreak.Diffuse.appdata.xml.in
@@ -37,6 +37,9 @@
   </screenshots>
 
   <developer_name translate="no">Romain Failliot</developer_name>
+  <developer id="io.github.mightycreak">
+    <name translate="no">Romain Failliot</name>
+  </developer>
   <update_contact>romain@foolstep.com</update_contact>
 
   <releases>

--- a/data/io.github.mightycreak.Diffuse.appdata.xml.in
+++ b/data/io.github.mightycreak.Diffuse.appdata.xml.in
@@ -36,7 +36,7 @@
     </screenshot>
   </screenshots>
 
-  <developer_name translatable="no">Romain Failliot</developer_name>
+  <developer_name translate="no">Romain Failliot</developer_name>
   <update_contact>romain@foolstep.com</update_contact>
 
   <releases>
@@ -65,7 +65,7 @@
       </description>
     </release>
     <release version="0.8.2" date="2023-04-16">
-      <description translatable="no">
+      <description translate="no">
         <p>Use more modern, symbolic icons, add Dutch translation, and a couple of small fixes.</p>
         <p>Added:</p>
         <ul>
@@ -88,7 +88,7 @@
       </description>
     </release>
     <release version="0.8.1" date="2023-04-07">
-      <description translatable="no">
+      <description translate="no">
         <p>
           Fix for the shortcuts that weren't working anymore due to migration to Gtk.Application.
         </p>
@@ -108,7 +108,7 @@
       </description>
     </release>
     <release version="0.8.0" date="2023-04-03">
-      <description translatable="no">
+      <description translate="no">
         <p>
           Update to GNOME 44, improved GTK 3 support, initial support for Rust, added Turkish and
           Georgian translations, and a couple of fixes.
@@ -145,7 +145,7 @@
       </description>
     </release>
     <release version="0.7.7" date="2022-10-23">
-      <description translatable="no">
+      <description translate="no">
         <p>
           Update translations.
         </p>
@@ -158,7 +158,7 @@
       </description>
     </release>
     <release version="0.7.6" date="2022-10-23">
-      <description translatable="no">
+      <description translate="no">
         <p>
           Add port to Mac OS.
         </p>
@@ -179,7 +179,7 @@
       </description>
     </release>
     <release version="0.7.5" date="2022-04-15">
-      <description translatable="no">
+      <description translate="no">
         <p>
           Crashfix and French translation.
         </p>
@@ -196,7 +196,7 @@
       </description>
     </release>
     <release version="0.7.4" date="2022-04-03">
-      <description translatable="no">
+      <description translate="no">
         <p>
           Mainly a maintenance release. It does increase the GNOME SDK's version.
         </p>
@@ -230,7 +230,7 @@
       </description>
     </release>
     <release version="0.7.3" date="2021-11-22">
-      <description translatable="no">
+      <description translate="no">
         <p>
           Patch release that introduces linters (flake8 and mypy).
         </p>
@@ -255,7 +255,7 @@
       </description>
     </release>
     <release version="0.7.2" date="2021-11-18">
-      <description translatable="no">
+      <description translate="no">
         <p>
           Patch release that fixes an error about APP_NAME and the Brazilian translation.
         </p>
@@ -283,7 +283,7 @@
       </description>
     </release>
     <release version="0.7.1" date="2021-11-17">
-      <description translatable="no">
+      <description translate="no">
         <p>
           Patch release to fix a bug when using the Flatpak package.
         </p>
@@ -297,7 +297,7 @@
       </description>
     </release>
     <release version="0.7.0" date="2021-11-16">
-      <description translatable="no">
+      <description translate="no">
         <p>
           With this release, the main end-user change is the new icon. The rest
           is mainly maintenance improvements with a much more standard folder
@@ -336,7 +336,7 @@
       </description>
     </release>
     <release version="0.6.0" date="2020-11-29">
-      <description translatable="no">
+      <description translate="no">
         <p>
           Mainly under the hood changes in this release, so nothing really
           visible to the users in this version. That said, I figured it was a
@@ -361,7 +361,7 @@
       </description>
     </release>
     <release version="0.5.0" date="2020-07-18">
-      <description translatable="no">
+      <description translate="no">
         <p>
           Here is the v0.5.0. Unintentionally, this release happens exactly 6
           years after the previous v0.4.8 release!


### PR DESCRIPTION
### appdata: translate=no properties

It appears that the appstream project no longer supports
`translatable=no` properties, and gettext extract them as translatable.

I opened an issue to inform about the situation, but `translatable=no`
properties are not accepted by developers. You can find the issue
here: `https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html

### appdata: Add developer ID

Flathub requires a developer tag and developer ID. Also Appstream decided to use rdns structure for developer ID.

It allows reverse-dns IDs like sh.cozy, de.geigi or Fediverse handle (like @user@example.org)

> A developer tag with a name child tag must be present.
> Only one developer tag is allowed and the name tag also must be present only once in untranslated form.

```
<developer id="tld.vendor">
  <name>Developer name</name>
</developer>
```
Source: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#name-summary-and-developer-name

> The element should have a id property, containing a unique ID to identify the component developer / development team. It is recommended to use a reverse-DNS name, like org.gnome or io.github.ximion, or a Fediverse handle (like @user@example.org) as ID to achieve a higher chance of uniqueness.

Source: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer