### PR TITLE
docs: fix incorrect flatpak command to install runtime SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update pypi packages (@MightyCreak)
 - Add pre-commit git hooks to run linters (@MightyCreak)
 
+### Fixed
+
+- Docs: fix incorrect flatpak command to install runtime SDK (@MightyCreak)
+
 ## 0.9.0 - 2024-01-13
 
 ### Changed

--- a/docs/developers/developers-setup.md
+++ b/docs/developers/developers-setup.md
@@ -81,7 +81,7 @@ pip3 install -r requirements.dev.txt
 To build, test and install Diffuse locally:
 
 ```sh
-flatpak install runtime/org.gnome.Sdk/$(uname -p)/44
+flatpak install runtime/org.gnome.Sdk/$(uname -m)/44
 flatpak-builder --user --install build-flatpak io.github.mightycreak.Diffuse.yml
 ```
 


### PR DESCRIPTION
Use `uname -m` (machine, e.g. "x86_64") instead of `uname -p` (processor).